### PR TITLE
2021-11-16 direct dataset manipulation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,26 @@ When already clone into a local directly via `git`, either use pip_ or install v
 
    python setup.py install
 
+For an editable install,
+
+
+..code:: bash
+
+   pip install -e .
+
+also run
+
+..code:: bash
+
+   glib-compile-schemas .
+
+from within subdirectory `dtool_lookup_gui`. Otherwise, GUI launch fails with
+
+..code::
+
+   gi.repository.GLib.Error: g-file-error-quark: Failed to open file “/path/to/repository/dtool_lookup_gui/gschemas.compiled”: open() failed: No such file or directory (4)
+
+
 Running the GUI
 ---------------
 

--- a/dtool_lookup_gui/.gitignore
+++ b/dtool_lookup_gui/.gitignore
@@ -1,0 +1,1 @@
+gschemas.compiled

--- a/dtool_lookup_gui/Dependencies.py
+++ b/dtool_lookup_gui/Dependencies.py
@@ -38,7 +38,6 @@ def _log_nested(log_func, dct):
         log_func(l)
 
 
-
 class DependencyGraph:
     def __init__(self):
         self._reset_graph()

--- a/dtool_lookup_gui/Dependencies.py
+++ b/dtool_lookup_gui/Dependencies.py
@@ -26,7 +26,9 @@ import json
 import logging
 import uuid
 
+from . import is_uuid
 from .SimpleGraph import SimpleGraph
+
 
 logger = logging.getLogger(__name__)
 
@@ -35,15 +37,6 @@ def _log_nested(log_func, dct):
     for l in json.dumps(dct, indent=2, default=str).splitlines():
         log_func(l)
 
-
-def is_uuid(value):
-    '''Check whether the data is a UUID.'''
-    value = str(value)
-    try:
-        uuid.UUID(value)
-        return True
-    except ValueError:
-        return False
 
 
 class DependencyGraph:

--- a/dtool_lookup_gui/DirectTab.py
+++ b/dtool_lookup_gui/DirectTab.py
@@ -1,0 +1,98 @@
+#
+# Copyright 2021 Johannes Hoermann, Lars Pastewka
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+import gi
+
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk, Gio
+
+from . import date_to_string
+
+from .models import (
+    LocalBaseURIModel,
+    DataSetListModel,
+    DataSetModel,
+    ProtoDataSetModel,
+    MetadataSchemaListModel,
+    UnsupportedTypeError,
+    BaseURIModel,
+)
+
+
+class SignalHandler:
+    def __init__(self, event_loop, builder, settings):
+        # local dataset management
+        self.base_uri_model = BaseURIModel()
+        self.dataset_list_model = DataSetListModel()
+        self.dataset_model = DataSetModel()
+
+        # Configure the models.
+        self.dataset_list_model.set_base_uri_model(self.base_uri_model)
+
+    def on_base_uri_set(self,  filechooserbutton):
+        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
+        base_uri_entry_buffer.set_text(filechooserbutton.get_uri(), -1)
+
+    def on_base_uri_open(self,  button):
+        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
+        results_widget = self.builder.get_object('dtool-ls-results')
+        statusbar_widget = self.builder.get_object('main-statusbar')
+
+        # base_uri = filechooserbutton.get_filename()
+        base_uri = base_uri_entry_buffer.get_text()
+        self.base_uri_model.put_base_uri(base_uri)
+
+        self.dataset_list_model.reindex()
+        statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} datasets.')
+
+        for entry in results_widget:
+            entry.destroy()
+
+        first_row = None
+
+        dataset_list_columns = ("uuid", "name", "size_str", "num_items", "creator", "date")
+        for props in self.dataset_list_model.yield_properties():
+            values = [props[c] for c in dataset_list_columns]
+            d = {c: v for c, v in zip(dataset_list_columns, values)}
+            row = Gtk.ListBoxRow()
+            if first_row is None:
+                first_row = row
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'<b>{d["uuid"]}</b>')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'{d["name"]}')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(
+                f'<small>Created by: {d["creator"]}, '
+                f'frozen at: '
+                f'{date_to_string(d["date"])}</small>')
+            vbox.pack_start(label, True, True, 0)
+            row.dataset = d
+            row.add(vbox)
+            results_widget.add(row)
+        results_widget.select_row(first_row)
+        results_widget.show_all()
+

--- a/dtool_lookup_gui/DirectTab.py
+++ b/dtool_lookup_gui/DirectTab.py
@@ -21,12 +21,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+import asyncio
 import gi
+
+import dtoolcore
+from dtoolcore import DataSet
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, Gio
 
-from . import date_to_string
+from . import date_to_string, _validate_readme
+
+from . import (
+    to_timestamp,
+    date_to_string,
+    datetime_to_string,
+    fill_readme_tree_store,
+    fill_manifest_tree_store)
 
 from .models import (
     LocalBaseURIModel,
@@ -41,17 +52,34 @@ from .models import (
 
 class SignalHandler:
     def __init__(self, event_loop, builder, settings):
-        # local dataset management
+        # self.event_loop = event_loop
+        self.builder = builder
+        # self.settings = settings
+
+        self.error_bar = self.builder.get_object('error-bar')
+        self.error_label = self.builder.get_object('error-label')
+
+        self._selected_dataset = None
+        self._selected_dataset_admin_metadata = None
+        self._readme = None
+        self._manifest = None
+
+        self.readme_stack = self.builder.get_object('direct-readme-stack')
+        self.manifest_stack = self.builder.get_object('direct-manifest-stack')
+
         self.base_uri_model = BaseURIModel()
         self.dataset_list_model = DataSetListModel()
         self.dataset_model = DataSetModel()
+
+        self._base_uri = None
 
         # Configure the models.
         self.dataset_list_model.set_base_uri_model(self.base_uri_model)
 
     def on_base_uri_set(self,  filechooserbutton):
         base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
-        base_uri_entry_buffer.set_text(filechooserbutton.get_uri(), -1)
+        self._base_uri = filechooserbutton.get_uri()
+        base_uri_entry_buffer.set_text(self._base_uri, -1)
 
     def on_base_uri_open(self,  button):
         base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
@@ -60,17 +88,19 @@ class SignalHandler:
 
         # base_uri = filechooserbutton.get_filename()
         base_uri = base_uri_entry_buffer.get_text()
+        self._base_uri = base_uri
         self.base_uri_model.put_base_uri(base_uri)
 
         self.dataset_list_model.reindex()
-        statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} datasets.')
+        self.refresh()
+        # statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} datasets.')
 
         for entry in results_widget:
             entry.destroy()
 
         first_row = None
 
-        dataset_list_columns = ("uuid", "name", "size_str", "num_items", "creator", "date")
+        dataset_list_columns = ("uuid", "name", "size_str", "num_items", "creator", "date", "uri")
         for props in self.dataset_list_model.yield_properties():
             values = [props[c] for c in dataset_list_columns]
             d = {c: v for c, v in zip(dataset_list_columns, values)}
@@ -96,3 +126,94 @@ class SignalHandler:
         results_widget.select_row(first_row)
         results_widget.show_all()
 
+    def on_direct_dataset_selected(self, list_box, list_box_row):
+        if list_box_row is None:
+            return
+
+        uri = list_box_row.dataset['uri']
+        self._selected_dataset = DataSet.from_uri(uri)
+        self._selected_dataset_admin_metadata = dtoolcore._admin_metadata_from_uri(uri, config_path=None)
+        self._readme = None
+        self._manifest = None
+
+        self.builder.get_object('direct-dataset-name').set_text(
+            self._selected_dataset.name)
+        self.builder.get_object('direct-dataset-uuid').set_text(
+            self._selected_dataset.uuid)
+        self.builder.get_object('direct-dataset-uri').set_text(
+            self._selected_dataset.uri)
+        self.builder.get_object('direct-dataset-created-by').set_text(
+            self._selected_dataset_admin_metadata['creator_username'])
+        self.builder.get_object('direct-dataset-created-at').set_text(
+            f'{datetime_to_string(self._selected_dataset_admin_metadata["created_at"])}')
+        self.builder.get_object('direct-dataset-frozen-at').set_text(
+            f'{datetime_to_string(self._selected_dataset_admin_metadata["frozen_at"])}')
+
+        page = self.builder.get_object('direct-dataset-notebook').get_property('page')
+        if page == 0:
+            self._readme_task = asyncio.ensure_future(
+                self._fetch_readme(self._selected_dataset.uri))
+        elif page == 1:
+            self._manifest_task = asyncio.ensure_future(
+                self._fetch_manifest(self._selected_dataset.uri))
+
+    async def _fetch_readme(self, uri):
+        self.error_bar.set_revealed(False)
+        self.readme_stack.set_visible_child(
+            self.builder.get_object('direct-readme-spinner'))
+
+        readme_view = self.builder.get_object('direct-dataset-readme')
+        store = readme_view.get_model()
+        store.clear()
+        _readme_content = self._selected_dataset.get_readme_content()
+        self._readme, error = _validate_readme(_readme_content)
+        if error is not None:
+            self.show_error(error)
+            self._readme = _readme_content
+        fill_readme_tree_store(store, self._readme)
+        readme_view.columns_autosize()
+        readme_view.show_all()
+
+        self.readme_stack.set_visible_child(
+            self.builder.get_object('direct-readme-view'))
+
+    async def _fetch_manifest(self, uri):
+        self.error_bar.set_revealed(False)
+        self.manifest_stack.set_visible_child(
+            self.builder.get_object('direct-manifest-spinner'))
+
+        manifest_view = self.builder.get_object('direct-dataset-manifest')
+        store = manifest_view.get_model()
+        store.clear()
+        self._manifest = self._selected_dataset._manifest
+        try:
+            fill_manifest_tree_store(store, self._manifest['items'])
+        except Exception as e:
+            print(e)
+        manifest_view.columns_autosize()
+        manifest_view.show_all()
+
+        self.manifest_stack.set_visible_child(
+            self.builder.get_object('direct-manifest-view'))
+
+    def on_direct_dataset_view_switch_page(self, notebook, page, page_num):
+        if self._selected_dataset is not None:
+            if page_num == 0 and self._readme is None:
+                self._readme_task = asyncio.ensure_future(
+                    self._fetch_readme(self._selected_dataset.uri))
+            elif page_num == 1 and self._manifest is None:
+                self._manifest_task = asyncio.ensure_future(
+                    self._fetch_manifest(self._selected_dataset.uri))
+
+    def refresh(self):
+        statusbar_widget = self.builder.get_object('main-statusbar')
+        if self._base_uri is not None:
+            statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} '
+                                     f'datasets - {self._base_uri}')
+        else:
+            statusbar_widget.push(0, f'Specfy base URI.')
+
+    def show_error(self, msg):
+        self.error_label.set_text(msg)
+        self.error_bar.show()
+        self.error_bar.set_revealed(True)

--- a/dtool_lookup_gui/DirectTab.py
+++ b/dtool_lookup_gui/DirectTab.py
@@ -24,7 +24,7 @@
 # TODO: Make pure use of Tjelvar's model layer, move direct access to data sets
 #       there
 # TODO: Metadata input via GUI
-# TODO:
+# TODO: Copy dataset via GUI
 import asyncio
 import gi
 gi.require_version('Gtk', '3.0')
@@ -60,6 +60,8 @@ from .models import (
     # MetadataSchemaListModel,
     UnsupportedTypeError,
 )
+
+HOME_DIR = os.path.expanduser("~")
 
 # Page numbers inverted, very weird
 DATASET_NOTEBOOK_README_PAGE = 0
@@ -109,10 +111,17 @@ class SignalHandler:
         self.dataset_list_model.set_base_uri_model(self.base_uri_model)
         # print(self.base_uri_model.get_base_uri())
         # Configure the models.
-        self._set_base_uri(self.base_uri_model.get_base_uri())
+        initial_base_uri = self.base_uri_model.get_base_uri()
+        if initial_base_uri is None:
+            initial_base_uri = HOME_DIR
+        self._set_base_uri(initial_base_uri)
         self._list_datasets()
 
-        self.dataset_list_model.set_active_index(0)
+        try:
+            self.dataset_list_model.set_active_index(0)
+        except IndexError as exc:
+            pass # Empty list, ignore
+
         dataset_uri = self.dataset_list_model.get_active_uri()
         # print(self.dataset_list_model.base_uri)
         if dataset_uri is not None:

--- a/dtool_lookup_gui/LookupTab.py
+++ b/dtool_lookup_gui/LookupTab.py
@@ -60,6 +60,8 @@ class SignalHandler:
         self.lookup = None
 
         self.error_bar = self.builder.get_object('error-bar')
+        self.error_label = self.builder.get_object('error-label')
+
         self.main_stack = self.builder.get_object('main-stack')
         self.readme_stack = self.builder.get_object('readme-stack')
         self.manifest_stack = self.builder.get_object('manifest-stack')
@@ -126,6 +128,9 @@ class SignalHandler:
 
         self.main_stack.set_visible_child(
             self.builder.get_object('main-view'))
+
+    def refresh(self):
+        self._refresh_results()
 
     async def _fetch_readme(self, uri):
         self.error_bar.set_revealed(False)
@@ -343,3 +348,8 @@ class SignalHandler:
         uuid = store.get_value(iter, 3)
         asyncio.ensure_future(
             self.retrieve_item(self._selected_dataset['uri'], item, uuid))
+
+    def show_error(self, msg):
+        self.error_label.set_text(msg)
+        self.error_bar.show()
+        self.error_bar.set_revealed(True)

--- a/dtool_lookup_gui/LookupTab.py
+++ b/dtool_lookup_gui/LookupTab.py
@@ -1,0 +1,345 @@
+#
+# Copyright 2020 Lars Pastewka
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import asyncio
+import concurrent.futures
+import shutil
+import subprocess
+from functools import reduce
+
+from . import (
+    to_timestamp,
+    date_to_string,
+    datetime_to_string,
+    fill_readme_tree_store,
+    fill_manifest_tree_store)
+import dtoolcore
+import dtool_lookup_api.core.config
+from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient as LookupClient
+dtool_lookup_api.core.config.Config.interactive = False
+
+import gi
+
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk, Gio
+
+import gbulb
+
+gbulb.install(gtk=True)
+
+from .Dependencies import DependencyGraph, is_uuid
+from .GraphWidget import GraphWidget
+
+
+class SignalHandler:
+    def __init__(self, event_loop, builder, settings):
+        self.event_loop = event_loop
+        self.builder = builder
+        self.settings = settings
+        self.lookup = None
+
+        self.error_bar = self.builder.get_object('error-bar')
+        self.main_stack = self.builder.get_object('main-stack')
+        self.readme_stack = self.builder.get_object('readme-stack')
+        self.manifest_stack = self.builder.get_object('manifest-stack')
+        self.dependency_stack = self.builder.get_object('dependency-stack')
+        self.search_popover = self.builder.get_object('search-popover')
+
+        self._search_task = None
+
+        self._selected_dataset = None
+        self._readme = None
+        self._manifest = None
+
+        self.main_stack.set_visible_child(
+            self.builder.get_object('main-spinner'))
+
+        self.datasets = None
+        self.server_config = None
+
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+
+    def _refresh_results(self):
+        results_widget = self.builder.get_object('search-results')
+        statusbar_widget = self.builder.get_object('main-statusbar')
+        if self.datasets is not None and self.server_config:
+            statusbar_widget.push(0, f'{len(self.datasets)} datasets - '
+                                     f'Connected to lookup server version '
+                                     f"{self.server_config['version']}")
+            if len(self.datasets) == 0:
+                self.main_stack.set_visible_child(
+                    self.builder.get_object('main-not-found'))
+                return
+        else:
+            statusbar_widget.push(0, 'Server connection failed')
+            self.main_stack.set_visible_child(
+                self.builder.get_object('main-not-found'))
+            return
+
+        for entry in results_widget:
+            entry.destroy()
+        first_row = None
+        for dataset in sorted(self.datasets,
+                              key=lambda d: -to_timestamp(d['frozen_at'])):
+            row = Gtk.ListBoxRow()
+            if first_row is None:
+                first_row = row
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'<b>{dataset["uuid"]}</b>')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'{dataset["name"]}')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(
+                f'<small>Created by: {dataset["creator_username"]}, '
+                f'frozen at: '
+                f'{date_to_string(dataset["frozen_at"])}</small>')
+            vbox.pack_start(label, True, True, 0)
+            row.dataset = dataset
+            row.add(vbox)
+            results_widget.add(row)
+        results_widget.select_row(first_row)
+        results_widget.show_all()
+
+        self.main_stack.set_visible_child(
+            self.builder.get_object('main-view'))
+
+    async def _fetch_readme(self, uri):
+        self.error_bar.set_revealed(False)
+        self.readme_stack.set_visible_child(
+            self.builder.get_object('readme-spinner'))
+
+        readme_view = self.builder.get_object('dataset-readme')
+        store = readme_view.get_model()
+        store.clear()
+        self._readme = await self.lookup.readme(uri)
+        fill_readme_tree_store(store, self._readme)
+        readme_view.columns_autosize()
+        readme_view.show_all()
+
+        self.readme_stack.set_visible_child(
+            self.builder.get_object('readme-view'))
+
+    async def _fetch_manifest(self, uri):
+        self.error_bar.set_revealed(False)
+        self.manifest_stack.set_visible_child(
+            self.builder.get_object('manifest-spinner'))
+
+        manifest_view = self.builder.get_object('dataset-manifest')
+        store = manifest_view.get_model()
+        store.clear()
+        self._manifest = await self.lookup.manifest(uri)
+        try:
+            fill_manifest_tree_store(store, self._manifest['items'])
+        except Exception as e:
+            print(e)
+        manifest_view.columns_autosize()
+        manifest_view.show_all()
+
+        self.manifest_stack.set_visible_child(
+            self.builder.get_object('manifest-view'))
+
+    async def _compute_dependencies(self, uri):
+        self.error_bar.set_revealed(False)
+        self.dependency_stack.set_visible_child(
+            self.builder.get_object('dependency-spinner'))
+
+        # Compute dependency graph
+        self._dependency_graph = DependencyGraph()
+        await self._dependency_graph.trace_dependencies(
+            self.lookup, self._selected_dataset['uuid'],
+            dependency_keys=self.settings.dependency_keys)
+
+        # Show message if uuids are missing
+        missing_uuids = self._dependency_graph.missing_uuids
+        if missing_uuids:
+            self.show_error('The following UUIDs were found during dependency graph calculation but are not present '
+                            'in the database: {}'.format(reduce(lambda a, b: a + ', ' + b, missing_uuids)))
+
+        # Create graph widget
+        graph_widget = GraphWidget(self.builder, self._dependency_graph.graph)
+        dependency_view = self.builder.get_object('dependency-view')
+        for child in dependency_view:
+            child.destroy()
+        dependency_view.pack_start(graph_widget, True, True, 0)
+        graph_widget.show()
+
+        self.dependency_stack.set_visible_child(dependency_view)
+
+    async def connect(self):
+        self.error_bar.set_revealed(False)
+        self.main_stack.set_visible_child(
+            self.builder.get_object('main-spinner'))
+
+        self.lookup = LookupClient(lookup_url=self.settings.lookup_url,
+                                   auth_url=self.settings.authenticator_url,
+                                   username=self.settings.username,
+                                   password=self.settings.password,
+                                   verify_ssl=False)
+        try:
+            await self.lookup.connect()
+            self.server_config = await self.lookup.config()
+            if 'msg' in self.server_config:
+                self.show_error(self.server_config['msg'])
+            self.datasets = await self.lookup.all()
+        except Exception as e:
+            self.show_error(str(e))
+            self.datasets = []
+        self._refresh_results()
+
+    def on_result_selected(self, list_box, list_box_row):
+        if list_box_row is None:
+            return
+        self._selected_dataset = list_box_row.dataset
+        self._readme = None
+        self._manifest = None
+        self._dependency_graph = None
+
+        self.builder.get_object('dataset-name').set_text(
+            self._selected_dataset['name'])
+        self.builder.get_object('dataset-uuid').set_text(
+            self._selected_dataset['uuid'])
+        self.builder.get_object('dataset-uri').set_text(
+            self._selected_dataset['uri'])
+        self.builder.get_object('dataset-created-by').set_text(
+            self._selected_dataset['creator_username'])
+        self.builder.get_object('dataset-created-at').set_text(
+            f'{datetime_to_string(self._selected_dataset["created_at"])}')
+        self.builder.get_object('dataset-frozen-at').set_text(
+            f'{datetime_to_string(self._selected_dataset["frozen_at"])}')
+
+        page = self.builder.get_object('dataset-notebook').get_property('page')
+        if page == 0:
+            self._readme_task = asyncio.ensure_future(
+                self._fetch_readme(self._selected_dataset['uri']))
+        elif page == 1:
+            self._manifest_task = asyncio.ensure_future(
+                self._fetch_manifest(self._selected_dataset['uri']))
+        elif page == 2:
+            self._dependency_task = asyncio.ensure_future(
+                self._compute_dependencies(self._selected_dataset['uri']))
+
+    def on_search_entry_button_press(self, search_entry, event):
+        """"Display larger text box popover for multiline search queries on double-click in search bar."""
+        if event.button == 1:
+            if event.type == Gdk.EventType._2BUTTON_PRESS:
+                search_text_buffer = self.builder.get_object('search-text-buffer')
+                search_entry_buffer = self.builder.get_object('search-entry-buffer')
+                search_text = search_entry_buffer.get_text()
+                search_text_buffer.set_text(search_text, -1)
+
+                rect = Gdk.Rectangle()
+                rect.x, rect.y = event.x, event.y
+                self.search_popover.set_pointing_to(rect)
+                self.search_popover.popup()
+
+    def on_search_button_clicked(self, button):
+        """"Update search bar text when clicking search button in search popover."""
+        search_text_buffer = self.builder.get_object('search-text-buffer')
+        search_entry_buffer = self.builder.get_object('search-entry-buffer')
+        start_iter = search_text_buffer.get_start_iter()
+        end_iter = search_text_buffer.get_end_iter()
+        search_text = search_text_buffer.get_text(start_iter, end_iter, True)
+        search_entry_buffer.set_text(search_text, -1)
+        self.search_popover.popdown()
+
+    def on_search(self, search_entry):
+        self.main_stack.set_visible_child(
+            self.builder.get_object('main-spinner'))
+
+        async def fetch_search_result(keyword):
+            if keyword:
+                if keyword.startswith('uuid:'):
+                    self.datasets = await self.lookup.by_uuid(keyword[5:])
+                elif keyword.startswith('{') and keyword.endswith('}'):
+                    # TODO: replace with proper syntax check on mongo query
+                    self.datasets = await self.lookup.by_query(keyword)
+                else:
+                    # NOTE: server side allows a dict with the key-value pairs
+                    # "free_text", "creator_usernames", "base_uris", "uuids", "tags",
+                    # via route '/dataset/search', where all except "free_text"
+                    # can be lists and are translated to logical "and" or "or"
+                    # constructs on the server side. With the special treatment
+                    # of the 'uuid' keyword above, should we introduce similar
+                    # options for the other available keywords?
+                    self.datasets = await self.lookup.search(keyword)
+            else:
+                self.datasets = await self.lookup.all()
+            self._refresh_results()
+
+        if self._search_task is not None:
+            self._search_task.cancel()
+        self._search_task = asyncio.ensure_future(
+            fetch_search_result(search_entry.get_text()))
+
+    def on_switch_page(self, notebook, page, page_num):
+        if self._selected_dataset is not None:
+            if page_num == 0 and self._readme is None:
+                self._readme_task = asyncio.ensure_future(
+                    self._fetch_readme(self._selected_dataset['uri']))
+            elif page_num == 1 and self._manifest is None:
+                self._manifest_task = asyncio.ensure_future(
+                    self._fetch_manifest(self._selected_dataset['uri']))
+            elif page_num == 2 and self._dependency_graph is None:
+                self._dependency_task = asyncio.ensure_future(
+                    self._compute_dependencies(self._selected_dataset['uri']))
+
+    def on_readme_row_activated(self, tree_view, path, column):
+        store = tree_view.get_model()
+        iter = store.get_iter(path)
+        is_uuid = store.get_value(iter, 2)
+        if is_uuid:
+            uuid = store.get_value(iter, 1)
+            self.builder.get_object('search-entry').set_text(f'uuid:{uuid}')
+            return True
+        return False
+
+    def dtool_retrieve_item(self, uri, item_name, item_uuid):
+        dataset = dtoolcore.DataSet.from_uri(uri)
+        if item_uuid in dataset.identifiers:
+            shutil.copyfile(dataset.item_content_abspath(item_uuid),
+                            f'/home/pastewka/Downloads/{item_name}')
+            subprocess.run(["xdg-open", f'/home/pastewka/Downloads/{item_name}'])
+            # The following lines should be more portable but don't run
+            #Gio.AppInfo.launch_default_for_uri(
+            #    dataset.item_content_abspath(uuid))
+        else:
+            self.show_error(f'Cannot open item {item_name}, since the UUID {item_uuid} '
+                            'appears to exist in the lookup server only.')
+
+    async def retrieve_item(self, uri, item_name, item_uuid):
+        loop = asyncio.get_event_loop()
+        await asyncio.wait([
+            loop.run_in_executor(self.thread_pool, self.dtool_retrieve_item,
+                                 uri, item_name, item_uuid)])
+
+    def on_manifest_row_activated(self, tree_view, path, column):
+        store = tree_view.get_model()
+        iter = store.get_iter(path)
+        item = store.get_value(iter, 0)
+        uuid = store.get_value(iter, 3)
+        asyncio.ensure_future(
+            self.retrieve_item(self._selected_dataset['uri'], item, uuid))

--- a/dtool_lookup_gui/MainApplication.py
+++ b/dtool_lookup_gui/MainApplication.py
@@ -136,13 +136,11 @@ class SignalHandler:
                 else:
                     self.handlers[method_name] = Trampoline([method])
 
-        # for method_name, methods in list(self.handlers.items())
-        #    if isinstance(methods, Trampoline):
-        #        self.handlers[method_name] = Trampoline
-        #    if len(methods) == 1:
-        #        self.handlers[method_name] = methods[0]
-        #    else:
-        #        self.handlers[method_name] = Trampoline(methods)
+    def on_main_switch_page(self, notebook, page, page_num):
+        if page_num == 0:
+            self.lookup_tab.refresh()
+        elif page_num == 1:
+            self.direct_tab.refresh()
 
     def on_settings_clicked(self, user_data):
         asyncio.create_task(self._fetch_users())

--- a/dtool_lookup_gui/MainApplication.py
+++ b/dtool_lookup_gui/MainApplication.py
@@ -149,7 +149,7 @@ class SignalHandler:
     def on_delete_settings(self, event, user_data):
         self.settings_window.hide()
         # Reconnect since settings may have been changed
-        asyncio.create_task(self.connect())
+        asyncio.create_task(self.lookup_tab.connect())
         return True
 
     def show_error(self, msg):

--- a/dtool_lookup_gui/MainApplication.py
+++ b/dtool_lookup_gui/MainApplication.py
@@ -38,6 +38,15 @@ import dtool_lookup_api.core.config
 from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient as LookupClient
 dtool_lookup_api.core.config.Config.interactive = False
 
+from dtool_gui_tk.models import (
+    LocalBaseURIModel,
+    DataSetListModel,
+    DataSetModel,
+    ProtoDataSetModel,
+    MetadataSchemaListModel,
+    UnsupportedTypeError,
+)
+
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -168,6 +177,27 @@ def fill_manifest_tree_store(store, data, parent=None):
                       f'{date_to_string(values["utc_timestamp"])}',
                       uuid])
 
+class BaseURIModel():
+    "Model for managing base URI."
+
+    def __init__(self, base_uri=os.path.curdir):
+        self.put_base_uri(base_uri)
+
+    def get_base_uri(self):
+        """Return the base URI.
+
+        :returns: base URI where datasets will be read from and written to
+        """
+        return self._base_uri
+
+    def put_base_uri(self, base_uri):
+        """Put/update the base URI.
+
+        :param base_uri: base URI
+        """
+        value = dtoolcore.utils.sanitise_uri(base_uri)
+        self._base_uri = value
+
 
 class Settings:
     def __init__(self):
@@ -232,6 +262,15 @@ class SignalHandler:
 
         self.datasets = None
         self.server_config = None
+
+        # local dataset management
+
+        self.base_uri_model = BaseURIModel()
+        self.dataset_list_model = DataSetListModel()
+        self.dataset_model = DataSetModel()
+
+        # Configure the models.
+        self.dataset_list_model.set_base_uri_model(self.base_uri_model)
 
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
@@ -549,6 +588,55 @@ class SignalHandler:
         uuid = store.get_value(iter, 3)
         asyncio.create_task(
             self.retrieve_item(self._selected_dataset['uri'], item, uuid))
+
+    # manage pane
+    def on_base_uri_set(self,  filechooserbutton):
+        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
+        base_uri_entry_buffer.set_text(filechooserbutton.get_uri(), -1)
+
+    def on_base_uri_open(self,  button):
+        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
+        results_widget = self.builder.get_object('dtool-ls-results')
+        statusbar_widget = self.builder.get_object('main-statusbar')
+
+        # base_uri = filechooserbutton.get_filename()
+        base_uri = base_uri_entry_buffer.get_text()
+        self.base_uri_model.put_base_uri(base_uri)
+
+        self.dataset_list_model.reindex()
+        statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} datasets.')
+
+        for entry in results_widget:
+            entry.destroy()
+
+        first_row = None
+
+        dataset_list_columns = ("uuid", "name", "size_str", "num_items", "creator", "date")
+        for props in self.dataset_list_model.yield_properties():
+            values = [props[c] for c in dataset_list_columns]
+            d = {c: v for c, v in zip(dataset_list_columns, values)}
+            row = Gtk.ListBoxRow()
+            if first_row is None:
+                first_row = row
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'<b>{d["uuid"]}</b>')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(f'{d["name"]}')
+            vbox.pack_start(label, True, True, 0)
+            label = Gtk.Label(xalign=0)
+            label.set_markup(
+                f'<small>Created by: {d["creator"]}, '
+                f'frozen at: '
+                f'{date_to_string(d["date"])}</small>')
+            vbox.pack_start(label, True, True, 0)
+            row.dataset = d
+            row.add(vbox)
+            results_widget.add(row)
+        results_widget.select_row(first_row)
+        results_widget.show_all()
+
 
 def run_gui():
     builder = Gtk.Builder()

--- a/dtool_lookup_gui/MainApplication.py
+++ b/dtool_lookup_gui/MainApplication.py
@@ -24,28 +24,11 @@
 
 import asyncio
 import concurrent.futures
-import locale
-import math
+import logging
 import os
-import shutil
-import subprocess
-from contextlib import contextmanager
-from datetime import date, datetime
-from functools import reduce
 
-import dtoolcore
 import dtool_lookup_api.core.config
-from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient as LookupClient
 dtool_lookup_api.core.config.Config.interactive = False
-
-from dtool_gui_tk.models import (
-    LocalBaseURIModel,
-    DataSetListModel,
-    DataSetModel,
-    ProtoDataSetModel,
-    MetadataSchemaListModel,
-    UnsupportedTypeError,
-)
 
 import gi
 
@@ -57,146 +40,23 @@ gbulb.install(gtk=True)
 #import asyncio_glib
 #asyncio.set_event_loop_policy(asyncio_glib.GLibEventLoopPolicy())
 
-from .Dependencies import DependencyGraph, is_uuid
-from .GraphWidget import GraphWidget
+from . import LookupTab, DirectTab
 
-def open(filename):
-    """Open file in system-default application"""
-    pass
+logger = logging.getLogger(__name__)
 
 
-@contextmanager
-def time_locale(name):
-    # This code snippet was taken from:
-    # https://stackoverflow.com/questions/18593661/how-do-i-strftime-a-date-object-in-a-different-locale
-    saved = locale.setlocale(locale.LC_TIME)
-    try:
-        yield locale.setlocale(locale.LC_TIME, name)
-    finally:
-        locale.setlocale(locale.LC_TIME, saved)
+# used for wrapping a list of signal handlers
+# source: https://github.com/LinuxCNC/linuxcnc/blob/master/src/emc/usr_intf/gscreen/gscreen.py
+class Trampoline(object):
+    def __init__(self, methods):
+        self.methods = methods
 
+    def __call__(self, *args, **kwargs):
+        for m in self.methods:
+            m(*args, **kwargs)
 
-def to_timestamp(d):
-    """
-    Convert a sting or a timestamp to a timestamp. This is a dirty fix necessary
-    because the /dataset/list route return timestamps but /dataset/search
-    returns strings in older versions of the lookup server (before 0.15.0).
-    """
-    if type(d) is str:
-        try:
-            with time_locale('C'):
-                d = dtoolcore.utils.timestamp(
-                    datetime.strptime(d, '%a, %d %b %Y %H:%M:%S %Z'))
-        except ValueError as e:
-            d = -1
-    return d
-
-
-def datetime_to_string(d):
-    return datetime.fromtimestamp(to_timestamp(d))
-
-
-def date_to_string(d):
-    return date.fromtimestamp(to_timestamp(d))
-
-
-def human_readable_file_size(num, suffix='B'):
-    # From: https://gist.github.com/cbwar/d2dfbc19b140bd599daccbe0fe925597
-    if num == 0:
-        return '0B'
-    magnitude = int(math.floor(math.log(num, 1024)))
-    val = num / math.pow(1024, magnitude)
-    if magnitude > 7:
-        return '{:.1f}{}{}'.format(val, 'Yi', suffix)
-    return '{:3.1f}{}{}'.format(val, ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi'][magnitude], suffix)
-
-
-def fill_readme_tree_store(store, data, parent=None):
-    def append_entry(store, entry, value, parent):
-        # Check whether the data is a UUID. We then enable a
-        # hyperlink-like navigation between datasets
-        is_u = is_uuid(value)
-        if is_u:
-            markup = '<span foreground="blue" underline="single">' \
-                     f'{str(value)}</span>'
-        else:
-            markup = f'<span>{str(value)}</span>'
-        store.append(parent,
-                     [entry, str(value), is_u, markup])
-
-    def fill_readme_tree_store_from_list(store, list_data, parent=None):
-        for i, current_data in enumerate(list_data):
-            entry = f'{i + 1}'
-            if type(current_data) is list:
-                current_parent = store.append(parent,
-                                              [entry, None, False, None])
-                fill_readme_tree_store_from_list(store, current_data,
-                                                 parent=current_parent)
-            elif type(current_data) is dict:
-                current_parent = store.append(parent,
-                                              [entry, None, False, None])
-                fill_readme_tree_store(store, current_data,
-                                       parent=current_parent)
-            else:
-                append_entry(store, entry, current_data, parent)
-
-    if data is not None:
-        for entry, value in data.items():
-            if type(value) is list:
-                current = store.append(parent,
-                                       [entry, None, False, None])
-                fill_readme_tree_store_from_list(store, value, parent=current)
-            elif type(value) is dict:
-                current = store.append(parent,
-                                       [entry, None, False, None])
-                fill_readme_tree_store(store, value, parent=current)
-            else:
-                append_entry(store, entry, value, parent)
-
-
-def fill_manifest_tree_store(store, data, parent=None):
-    nodes = {}
-
-    def find_or_create_parent_node(path, top_parent):
-        if not path:
-            return top_parent
-        try:
-            return nodes[path]
-        except KeyError:
-            head, tail = os.path.split(path)
-            parent = find_or_create_parent_node(head, top_parent)
-            new_node = store.append(parent, [tail, '', '', ''])
-            nodes[path] = new_node
-            return new_node
-
-    for uuid, values in sorted(data.items(), key=lambda kv: kv[1]['relpath']):
-        head, tail = os.path.split(values['relpath'])
-        store.append(find_or_create_parent_node(head, parent),
-                     [tail,
-                      human_readable_file_size(values['size_in_bytes']),
-                      f'{date_to_string(values["utc_timestamp"])}',
-                      uuid])
-
-class BaseURIModel():
-    "Model for managing base URI."
-
-    def __init__(self, base_uri=os.path.curdir):
-        self.put_base_uri(base_uri)
-
-    def get_base_uri(self):
-        """Return the base URI.
-
-        :returns: base URI where datasets will be read from and written to
-        """
-        return self._base_uri
-
-    def put_base_uri(self, base_uri):
-        """Put/update the base URI.
-
-        :param base_uri: base URI
-        """
-        value = dtoolcore.utils.sanitise_uri(base_uri)
-        self._base_uri = value
+    def append(self, method):
+        self.methods.append(method)
 
 
 class Settings:
@@ -234,301 +94,55 @@ class SignalHandler:
         self.event_loop = event_loop
         self.builder = builder
         self.settings = settings
-        self.lookup = None
 
         self.main_window = self.builder.get_object('main-window')
         self.settings_window = self.builder.get_object('settings-window')
 
-        self.main_stack = self.builder.get_object('main-stack')
-        self.readme_stack = self.builder.get_object('readme-stack')
-        self.manifest_stack = self.builder.get_object('manifest-stack')
-        self.dependency_stack = self.builder.get_object('dependency-stack')
-
         self.error_bar = self.builder.get_object('error-bar')
         self.error_label = self.builder.get_object('error-label')
 
-        self.search_popover = self.builder.get_object('search-popover')
-
         self.error_bar.set_revealed(False)
-
-        self._search_task = None
-
-        self._selected_dataset = None
-        self._readme = None
-        self._manifest = None
-
-        self.main_stack.set_visible_child(
-            self.builder.get_object('main-spinner'))
-
-        self.datasets = None
-        self.server_config = None
-
-        # local dataset management
-
-        self.base_uri_model = BaseURIModel()
-        self.dataset_list_model = DataSetListModel()
-        self.dataset_model = DataSetModel()
-
-        # Configure the models.
-        self.dataset_list_model.set_base_uri_model(self.base_uri_model)
 
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
-    def _refresh_results(self):
-        results_widget = self.builder.get_object('search-results')
-        statusbar_widget = self.builder.get_object('main-statusbar')
-        if self.datasets is not None and self.server_config:
-            statusbar_widget.push(0, f'{len(self.datasets)} datasets - '
-                                     f'Connected to lookup server version '
-                                     f"{self.server_config['version']}")
-            if len(self.datasets) == 0:
-                self.main_stack.set_visible_child(
-                    self.builder.get_object('main-not-found'))
-                return
+        self.lookup_tab = LookupTab.SignalHandler(event_loop, builder, settings)
+        self.direct_tab = DirectTab.SignalHandler(event_loop, builder, settings)
+
+        # Create a dictionary to hold the signal-handler pairs
+        self.handlers = {}
+
+        # load all signal handlers into sel.handlers
+        self._load_handlers(self.lookup_tab)
+        self._load_handlers(self.direct_tab)
+        self._load_handlers(self)
+
+        self.builder.connect_signals(self.handlers)
+        self.builder.get_object('main-window').show_all()
+
+    def _load_handlers(self, object):
+        """Scan object for signal handlers and add them to a (class-global) """
+        if isinstance(object, dict):
+            methods = object.items()
         else:
-            statusbar_widget.push(0, 'Server connection failed')
-            self.main_stack.set_visible_child(
-                self.builder.get_object('main-not-found'))
-            return
+            methods = map(lambda n: (n, getattr(object, n, None)), dir(object))
 
-        for entry in results_widget:
-            entry.destroy()
-        first_row = None
-        for dataset in sorted(self.datasets,
-                              key=lambda d: -to_timestamp(d['frozen_at'])):
-            row = Gtk.ListBoxRow()
-            if first_row is None:
-                first_row = row
-            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(f'<b>{dataset["uuid"]}</b>')
-            vbox.pack_start(label, True, True, 0)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(f'{dataset["name"]}')
-            vbox.pack_start(label, True, True, 0)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(
-                f'<small>Created by: {dataset["creator_username"]}, '
-                f'frozen at: '
-                f'{date_to_string(dataset["frozen_at"])}</small>')
-            vbox.pack_start(label, True, True, 0)
-            row.dataset = dataset
-            row.add(vbox)
-            results_widget.add(row)
-        results_widget.select_row(first_row)
-        results_widget.show_all()
-
-        self.main_stack.set_visible_child(
-            self.builder.get_object('main-view'))
-
-    async def _fetch_readme(self, uri):
-        self.error_bar.set_revealed(False)
-        self.readme_stack.set_visible_child(
-            self.builder.get_object('readme-spinner'))
-
-        readme_view = self.builder.get_object('dataset-readme')
-        store = readme_view.get_model()
-        store.clear()
-        self._readme = await self.lookup.readme(uri)
-        fill_readme_tree_store(store, self._readme)
-        readme_view.columns_autosize()
-        readme_view.show_all()
-
-        self.readme_stack.set_visible_child(
-            self.builder.get_object('readme-view'))
-
-    async def _fetch_manifest(self, uri):
-        self.error_bar.set_revealed(False)
-        self.manifest_stack.set_visible_child(
-            self.builder.get_object('manifest-spinner'))
-
-        manifest_view = self.builder.get_object('dataset-manifest')
-        store = manifest_view.get_model()
-        store.clear()
-        self._manifest = await self.lookup.manifest(uri)
-        try:
-            fill_manifest_tree_store(store, self._manifest['items'])
-        except Exception as e:
-            print(e)
-        manifest_view.columns_autosize()
-        manifest_view.show_all()
-
-        self.manifest_stack.set_visible_child(
-            self.builder.get_object('manifest-view'))
-
-    async def _fetch_users(self):
-        #self.error_bar.set_revealed(False)
-        #self.manifest_stack.set_visible_child(
-        #    self.builder.get_object('manifest-spinner'))
-
-        users_view = self.builder.get_object('settings-users')
-        store = users_view.get_model()
-        store.clear()
-
-        base_uris = await self.lookup.list_base_uris()
-
-        users = []
-        for base_uri in base_uris:
-            for user in base_uri['users_with_register_permissions'] + base_uri['users_with_search_permissions']:
-                users += [(user, base_uri,
-                           user in base_uri['users_with_search_permissions'],
-                           user in base_uri['users_with_register_permissions'])]
-
-        for user, base_uri, has_search_permission, has_register_permission in users:
-            store.append(None, [user, False, has_search_permission, has_register_permission])
-
-        #try:
-        #    fill_manifest_tree_store(store, self._manifest['items'])
-        #except Exception as e:
-        #    print(e)
-        users_view.columns_autosize()
-        users_view.show_all()
-
-    async def _compute_dependencies(self, uri):
-        self.error_bar.set_revealed(False)
-        self.dependency_stack.set_visible_child(
-            self.builder.get_object('dependency-spinner'))
-
-        # Compute dependency graph
-        self._dependency_graph = DependencyGraph()
-        await self._dependency_graph.trace_dependencies(
-            self.lookup, self._selected_dataset['uuid'],
-            dependency_keys=self.settings.dependency_keys)
-
-        # Show message if uuids are missing
-        missing_uuids = self._dependency_graph.missing_uuids
-        if missing_uuids:
-            self.show_error('The following UUIDs were found during dependency graph calculation but are not present '
-                            'in the database: {}'.format(reduce(lambda a, b: a + ', ' + b, missing_uuids)))
-
-        # Create graph widget
-        graph_widget = GraphWidget(self.builder, self._dependency_graph.graph)
-        dependency_view = self.builder.get_object('dependency-view')
-        for child in dependency_view:
-            child.destroy()
-        dependency_view.pack_start(graph_widget, True, True, 0)
-        graph_widget.show()
-
-        self.dependency_stack.set_visible_child(dependency_view)
-
-    async def connect(self):
-        self.error_bar.set_revealed(False)
-        self.main_stack.set_visible_child(
-            self.builder.get_object('main-spinner'))
-
-        self.lookup = LookupClient(lookup_url=self.settings.lookup_url,
-                                   auth_url=self.settings.authenticator_url,
-                                   username=self.settings.username,
-                                   password=self.settings.password,
-                                   verify_ssl=False)
-        try:
-            await self.lookup.connect()
-            self.server_config = await self.lookup.config()
-            if 'msg' in self.server_config:
-                self.show_error(self.server_config['msg'])
-            self.datasets = await self.lookup.all()
-        except Exception as e:
-            self.show_error(str(e))
-            self.datasets = []
-        self._refresh_results()
-
-    def show_error(self, msg):
-        self.error_label.set_text(msg)
-        self.error_bar.show()
-        self.error_bar.set_revealed(True)
-
-    def on_window_destroy(self, *args):
-        self.event_loop.stop()
-
-    def on_result_selected(self, list_box, list_box_row):
-        if list_box_row is None:
-            return
-        self._selected_dataset = list_box_row.dataset
-        self._readme = None
-        self._manifest = None
-        self._dependency_graph = None
-
-        self.builder.get_object('dataset-name').set_text(
-            self._selected_dataset['name'])
-        self.builder.get_object('dataset-uuid').set_text(
-            self._selected_dataset['uuid'])
-        self.builder.get_object('dataset-uri').set_text(
-            self._selected_dataset['uri'])
-        self.builder.get_object('dataset-created-by').set_text(
-            self._selected_dataset['creator_username'])
-        self.builder.get_object('dataset-created-at').set_text(
-            f'{datetime_to_string(self._selected_dataset["created_at"])}')
-        self.builder.get_object('dataset-frozen-at').set_text(
-            f'{datetime_to_string(self._selected_dataset["frozen_at"])}')
-        if 'size_in_bytes' in self._selected_dataset and self._selected_dataset['size_in_bytes'] is not None:
-            self.builder.get_object('dataset-size-in-bytes').set_text(
-                f'{human_readable_file_size(self._selected_dataset["size_in_bytes"])}')
-        else:
-            self.builder.get_object('dataset-size-in-bytes').set_text('N/A')
-
-        page = self.builder.get_object('dataset-notebook').get_property('page')
-        if page == 0:
-            self._readme_task = asyncio.create_task(
-                self._fetch_readme(self._selected_dataset['uri']))
-        elif page == 1:
-            self._manifest_task = asyncio.create_task(
-                self._fetch_manifest(self._selected_dataset['uri']))
-        elif page == 2:
-            self._dependency_task = asyncio.create_task(
-                self._compute_dependencies(self._selected_dataset['uri']))
-
-    def on_search_entry_button_press(self, search_entry, event):
-        """"Display larger text box popover for multiline search queries on double-click in search bar."""
-        if event.button == 1:
-            if event.type == Gdk.EventType._2BUTTON_PRESS:
-                search_text_buffer = self.builder.get_object('search-text-buffer')
-                search_entry_buffer = self.builder.get_object('search-entry-buffer')
-                search_text = search_entry_buffer.get_text()
-                search_text_buffer.set_text(search_text, -1)
-
-                rect = Gdk.Rectangle()
-                rect.x, rect.y = event.x, event.y
-                self.search_popover.set_pointing_to(rect)
-                self.search_popover.popup()
-
-    def on_search_button_clicked(self, button):
-        """"Update search bar text when clicking search button in search popover."""
-        search_text_buffer = self.builder.get_object('search-text-buffer')
-        search_entry_buffer = self.builder.get_object('search-entry-buffer')
-        start_iter = search_text_buffer.get_start_iter()
-        end_iter = search_text_buffer.get_end_iter()
-        search_text = search_text_buffer.get_text(start_iter, end_iter, True)
-        search_entry_buffer.set_text(search_text, -1)
-        self.search_popover.popdown()
-
-    def on_search(self, search_entry):
-        self.main_stack.set_visible_child(
-            self.builder.get_object('main-spinner'))
-
-        async def fetch_search_result(keyword):
-            if keyword:
-                if keyword.startswith('uuid:'):
-                    self.datasets = await self.lookup.by_uuid(keyword[5:])
-                elif keyword.startswith('{') and keyword.endswith('}'):
-                    # TODO: replace with proper syntax check on mongo query
-                    self.datasets = await self.lookup.by_query(keyword)
+        for method_name, method in methods:
+            if method_name.startswith('_'):
+                continue
+            if callable(method):
+                print("Registering callback %s" % (method_name))
+                if method_name in self.handlers:
+                    self.handlers[method_name].append(method)
                 else:
-                    # NOTE: server side allows a dict with the key-value pairs
-                    # "free_text", "creator_usernames", "base_uris", "uuids", "tags",
-                    # via route '/dataset/search', where all except "free_text"
-                    # can be lists and are translated to logical "and" or "or"
-                    # constructs on the server side. With the special treatment
-                    # of the 'uuid' keyword above, should we introduce similar
-                    # options for the other available keywords?
-                    self.datasets = await self.lookup.search(keyword)
-            else:
-                self.datasets = await self.lookup.all()
-            self._refresh_results()
+                    self.handlers[method_name] = Trampoline([method])
 
-        if self._search_task is not None:
-            self._search_task.cancel()
-        self._search_task = asyncio.create_task(
-            fetch_search_result(search_entry.get_text()))
+        # for method_name, methods in list(self.handlers.items())
+        #    if isinstance(methods, Trampoline):
+        #        self.handlers[method_name] = Trampoline
+        #    if len(methods) == 1:
+        #        self.handlers[method_name] = methods[0]
+        #    else:
+        #        self.handlers[method_name] = Trampoline(methods)
 
     def on_settings_clicked(self, user_data):
         asyncio.create_task(self._fetch_users())
@@ -540,102 +154,13 @@ class SignalHandler:
         asyncio.create_task(self.connect())
         return True
 
-    def on_switch_page(self, notebook, page, page_num):
-        if self._selected_dataset is not None:
-            if page_num == 0 and self._readme is None:
-                self._readme_task = asyncio.create_task(
-                    self._fetch_readme(self._selected_dataset['uri']))
-            elif page_num == 1 and self._manifest is None:
-                self._manifest_task = asyncio.create_task(
-                    self._fetch_manifest(self._selected_dataset['uri']))
-            elif page_num == 2 and self._dependency_graph is None:
-                self._dependency_task = asyncio.create_task(
-                    self._compute_dependencies(self._selected_dataset['uri']))
+    def show_error(self, msg):
+        self.error_label.set_text(msg)
+        self.error_bar.show()
+        self.error_bar.set_revealed(True)
 
-    def on_readme_row_activated(self, tree_view, path, column):
-        store = tree_view.get_model()
-        iter = store.get_iter(path)
-        is_uuid = store.get_value(iter, 2)
-        if is_uuid:
-            uuid = store.get_value(iter, 1)
-            self.builder.get_object('search-entry').set_text(f'uuid:{uuid}')
-            return True
-        return False
-
-    def dtool_retrieve_item(self, uri, item_name, item_uuid):
-        dataset = dtoolcore.DataSet.from_uri(uri)
-        if item_uuid in dataset.identifiers:
-            shutil.copyfile(dataset.item_content_abspath(item_uuid),
-                            f'/home/pastewka/Downloads/{item_name}')
-            subprocess.run(["xdg-open", f'/home/pastewka/Downloads/{item_name}'])
-            # The following lines should be more portable but don't run
-            #Gio.AppInfo.launch_default_for_uri(
-            #    dataset.item_content_abspath(uuid))
-        else:
-            self.show_error(f'Cannot open item {item_name}, since the UUID {uuid_name} '
-                            'appears to exist in the lookup server only.')
-
-    async def retrieve_item(self, uri, item_name, item_uuid):
-        loop = asyncio.get_event_loop()
-        await asyncio.wait([
-            loop.run_in_executor(self.thread_pool, self.dtool_retrieve_item,
-                                 uri, item_name, item_uuid)])
-
-    def on_manifest_row_activated(self, tree_view, path, column):
-        store = tree_view.get_model()
-        iter = store.get_iter(path)
-        item = store.get_value(iter, 0)
-        uuid = store.get_value(iter, 3)
-        asyncio.create_task(
-            self.retrieve_item(self._selected_dataset['uri'], item, uuid))
-
-    # manage pane
-    def on_base_uri_set(self,  filechooserbutton):
-        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
-        base_uri_entry_buffer.set_text(filechooserbutton.get_uri(), -1)
-
-    def on_base_uri_open(self,  button):
-        base_uri_entry_buffer = self.builder.get_object('base-uri-entry-buffer')
-        results_widget = self.builder.get_object('dtool-ls-results')
-        statusbar_widget = self.builder.get_object('main-statusbar')
-
-        # base_uri = filechooserbutton.get_filename()
-        base_uri = base_uri_entry_buffer.get_text()
-        self.base_uri_model.put_base_uri(base_uri)
-
-        self.dataset_list_model.reindex()
-        statusbar_widget.push(0, f'{len(self.dataset_list_model._datasets)} datasets.')
-
-        for entry in results_widget:
-            entry.destroy()
-
-        first_row = None
-
-        dataset_list_columns = ("uuid", "name", "size_str", "num_items", "creator", "date")
-        for props in self.dataset_list_model.yield_properties():
-            values = [props[c] for c in dataset_list_columns]
-            d = {c: v for c, v in zip(dataset_list_columns, values)}
-            row = Gtk.ListBoxRow()
-            if first_row is None:
-                first_row = row
-            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(f'<b>{d["uuid"]}</b>')
-            vbox.pack_start(label, True, True, 0)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(f'{d["name"]}')
-            vbox.pack_start(label, True, True, 0)
-            label = Gtk.Label(xalign=0)
-            label.set_markup(
-                f'<small>Created by: {d["creator"]}, '
-                f'frozen at: '
-                f'{date_to_string(d["date"])}</small>')
-            vbox.pack_start(label, True, True, 0)
-            row.dataset = d
-            row.add(vbox)
-            results_widget.add(row)
-        results_widget.select_row(first_row)
-        results_widget.show_all()
+    def on_window_destroy(self, *args):
+        self.event_loop.stop()
 
 
 def run_gui():
@@ -647,9 +172,7 @@ def run_gui():
     settings = Settings()
 
     signal_handler = SignalHandler(loop, builder, settings)
-    builder.connect_signals(signal_handler)
-
-    builder.get_object('main-window').show_all()
+    # builder.connect_signals(signal_handler)
 
     settings.settings.bind("lookup-url", builder.get_object('lookup-url-entry'),
                            'text', Gio.SettingsBindFlags.DEFAULT)
@@ -667,6 +190,6 @@ def run_gui():
                            Gio.SettingsBindFlags.DEFAULT)
 
     # Connect to the lookup server upon startup
-    loop.create_task(signal_handler.connect())
+    loop.create_task(signal_handler.lookup_tab.connect())
 
     loop.run_forever()

--- a/dtool_lookup_gui/MainApplication.py
+++ b/dtool_lookup_gui/MainApplication.py
@@ -130,7 +130,7 @@ class SignalHandler:
             if method_name.startswith('_'):
                 continue
             if callable(method):
-                print("Registering callback %s" % (method_name))
+                logger.debug("Registering callback %s" % (method_name))
                 if method_name in self.handlers:
                     self.handlers[method_name].append(method)
                 else:

--- a/dtool_lookup_gui/__init__.py
+++ b/dtool_lookup_gui/__init__.py
@@ -109,12 +109,12 @@ def fill_readme_tree_store(store, data, parent=None):
     def fill_readme_tree_store_from_list(store, list_data, parent=None):
         for i, current_data in enumerate(list_data):
             entry = f'{i + 1}'
-            if type(current_data) is list:
+            if isinstance(current_data, list):
                 current_parent = store.append(parent,
                                               [entry, None, False, None])
                 fill_readme_tree_store_from_list(store, current_data,
                                                  parent=current_parent)
-            elif type(current_data) is dict:
+            elif isinstance(current_data, dict):
                 current_parent = store.append(parent,
                                               [entry, None, False, None])
                 fill_readme_tree_store(store, current_data,
@@ -124,11 +124,11 @@ def fill_readme_tree_store(store, data, parent=None):
 
     if data is not None:
         for entry, value in data.items():
-            if type(value) is list:
+            if isinstance(value, list):
                 current = store.append(parent,
                                        [entry, None, False, None])
                 fill_readme_tree_store_from_list(store, value, parent=current)
-            elif type(value) is dict:
+            elif isinstance(value, dict):
                 current = store.append(parent,
                                        [entry, None, False, None])
                 fill_readme_tree_store(store, value, parent=current)

--- a/dtool_lookup_gui/__init__.py
+++ b/dtool_lookup_gui/__init__.py
@@ -1,0 +1,155 @@
+#
+# Copyright 2020, 2021 Lars Pastewka, Johannes Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import locale
+import math
+import os
+import uuid
+from contextlib import contextmanager
+from datetime import date, datetime
+
+import dtoolcore
+
+
+@contextmanager
+def time_locale(name):
+    # This code snippet was taken from:
+    # https://stackoverflow.com/questions/18593661/how-do-i-strftime-a-date-object-in-a-different-locale
+    saved = locale.setlocale(locale.LC_TIME)
+    try:
+        yield locale.setlocale(locale.LC_TIME, name)
+    finally:
+        locale.setlocale(locale.LC_TIME, saved)
+
+
+def is_uuid(value):
+    '''Check whether the data is a UUID.'''
+    value = str(value)
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+def to_timestamp(d):
+    """
+    Convert a sting or a timestamp to a timestamp. This is a dirty fix necessary
+    because the /dataset/list route return timestamps but /dataset/search
+    returns strings in older versions of the lookup server (before 0.15.0).
+    """
+    if type(d) is str:
+        try:
+            with time_locale('C'):
+                d = dtoolcore.utils.timestamp(
+                    datetime.strptime(d, '%a, %d %b %Y %H:%M:%S %Z'))
+        except ValueError as e:
+            d = -1
+    return d
+
+
+def datetime_to_string(d):
+    return datetime.fromtimestamp(to_timestamp(d))
+
+
+def date_to_string(d):
+    return date.fromtimestamp(to_timestamp(d))
+
+
+def human_readable_file_size(num, suffix='B'):
+    # From: https://gist.github.com/cbwar/d2dfbc19b140bd599daccbe0fe925597
+    if num == 0:
+        return '0B'
+    magnitude = int(math.floor(math.log(num, 1024)))
+    val = num / math.pow(1024, magnitude)
+    if magnitude > 7:
+        return '{:.1f}{}{}'.format(val, 'Yi', suffix)
+    return '{:3.1f}{}{}'.format(val, ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi'][magnitude], suffix)
+
+
+def fill_readme_tree_store(store, data, parent=None):
+    def append_entry(store, entry, value, parent):
+        # Check whether the data is a UUID. We then enable a
+        # hyperlink-like navigation between datasets
+        is_u = is_uuid(value)
+        if is_u:
+            markup = '<span foreground="blue" underline="single">' \
+                     f'{str(value)}</span>'
+        else:
+            markup = f'<span>{str(value)}</span>'
+        store.append(parent,
+                     [entry, str(value), is_u, markup])
+
+    def fill_readme_tree_store_from_list(store, list_data, parent=None):
+        for i, current_data in enumerate(list_data):
+            entry = f'{i + 1}'
+            if type(current_data) is list:
+                current_parent = store.append(parent,
+                                              [entry, None, False, None])
+                fill_readme_tree_store_from_list(store, current_data,
+                                                 parent=current_parent)
+            elif type(current_data) is dict:
+                current_parent = store.append(parent,
+                                              [entry, None, False, None])
+                fill_readme_tree_store(store, current_data,
+                                       parent=current_parent)
+            else:
+                append_entry(store, entry, current_data, parent)
+
+    if data is not None:
+        for entry, value in data.items():
+            if type(value) is list:
+                current = store.append(parent,
+                                       [entry, None, False, None])
+                fill_readme_tree_store_from_list(store, value, parent=current)
+            elif type(value) is dict:
+                current = store.append(parent,
+                                       [entry, None, False, None])
+                fill_readme_tree_store(store, value, parent=current)
+            else:
+                append_entry(store, entry, value, parent)
+
+
+def fill_manifest_tree_store(store, data, parent=None):
+    nodes = {}
+
+    def find_or_create_parent_node(path, top_parent):
+        if not path:
+            return top_parent
+        try:
+            return nodes[path]
+        except KeyError:
+            head, tail = os.path.split(path)
+            parent = find_or_create_parent_node(head, top_parent)
+            new_node = store.append(parent, [tail, '', '', ''])
+            nodes[path] = new_node
+            return new_node
+
+    for uuid, values in sorted(data.items(), key=lambda kv: kv[1]['relpath']):
+        head, tail = os.path.split(values['relpath'])
+        store.append(find_or_create_parent_node(head, parent),
+                     [tail,
+                      human_readable_file_size(values['size_in_bytes']),
+                      f'{date_to_string(values["utc_timestamp"])}',
+                      uuid])

--- a/dtool_lookup_gui/__init__.py
+++ b/dtool_lookup_gui/__init__.py
@@ -29,6 +29,11 @@ import uuid
 from contextlib import contextmanager
 from datetime import date, datetime
 
+from ruamel.yaml import YAML
+from ruamel.yaml.parser import ParserError
+from ruamel.yaml.constructor import DuplicateKeyError
+from ruamel.yaml.scanner import ScannerError
+
 import dtoolcore
 
 
@@ -153,3 +158,14 @@ def fill_manifest_tree_store(store, data, parent=None):
                       human_readable_file_size(values['size_in_bytes']),
                       f'{date_to_string(values["utc_timestamp"])}',
                       uuid])
+
+
+def _validate_readme(readme_content):
+    """Return (YAML string, error message)."""
+    yaml = YAML()
+    # Ensure that the content is valid YAML.
+    try:
+        readme_formatted = yaml.load(readme_content)
+        return readme_formatted, None
+    except (ParserError, DuplicateKeyError, ScannerError) as message:
+        return None, str(message)

--- a/dtool_lookup_gui/__main__.py
+++ b/dtool_lookup_gui/__main__.py
@@ -23,5 +23,40 @@
 #
 
 if __name__ == '__main__':
+    import logging
+    import argparse
+
     from .MainApplication import run_gui
+
+
+    # in order to have both:
+    # * preformatted help text and ...
+    # * automatic display of defaults
+    class ArgumentDefaultsAndRawDescriptionHelpFormatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+        pass
+
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=ArgumentDefaultsAndRawDescriptionHelpFormatter)
+
+    parser.add_argument('--verbose', '-v', action='count', dest='verbose',
+                        default=0, help='Make terminal output more verbose')
+    parser.add_argument('--debug', '-d', action='store_true',
+                        help='Print debug info')
+    args = parser.parse_args()
+
+    loglevel = logging.ERROR
+
+    if args.verbose > 0:
+        loglevel = logging.WARN
+    if args.verbose > 1:
+        loglevel = logging.INFO
+    if args.debug or (args.verbose > 2):
+        loglevel = logging.DEBUG
+
+    # explicitly modify the root logger
+    logging.basicConfig(level=loglevel)
+    logger = logging.getLogger()
+    logger.setLevel(loglevel)
+
     run_gui()

--- a/dtool_lookup_gui/dtool-lookup-gui.glade
+++ b/dtool_lookup_gui/dtool-lookup-gui.glade
@@ -186,6 +186,55 @@
       </object>
     </child>
   </object>
+  <object class="GtkTreeStore" id="direct-manifest-treestore">
+    <columns>
+      <!-- column-name name -->
+      <column type="gchararray"/>
+      <!-- column-name size -->
+      <column type="gchararray"/>
+      <!-- column-name date -->
+      <column type="gchararray"/>
+      <!-- column-name uuid -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkTreeStore" id="direct-readme-treestore">
+    <columns>
+      <!-- column-name key -->
+      <column type="gchararray"/>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+      <!-- column-name is_uuid -->
+      <column type="gboolean"/>
+      <!-- column-name markup -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkEntryCompletion" id="entrycompletion1"/>
+  <object class="GtkTreeStore" id="lookup-manifest-treestore">
+    <columns>
+      <!-- column-name name -->
+      <column type="gchararray"/>
+      <!-- column-name size -->
+      <column type="gchararray"/>
+      <!-- column-name date -->
+      <column type="gchararray"/>
+      <!-- column-name uuid -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkTreeStore" id="lookup-readme-treestore">
+    <columns>
+      <!-- column-name key -->
+      <column type="gchararray"/>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+      <!-- column-name is_uuid -->
+      <column type="gboolean"/>
+      <!-- column-name markup -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkPopoverMenu" id="main-menu">
     <property name="can-focus">False</property>
     <child>
@@ -250,30 +299,6 @@
         <property name="use-underline">True</property>
       </object>
     </child>
-  </object>
-  <object class="GtkTreeStore" id="manifest-treestore">
-    <columns>
-      <!-- column-name name -->
-      <column type="gchararray"/>
-      <!-- column-name size -->
-      <column type="gchararray"/>
-      <!-- column-name date -->
-      <column type="gchararray"/>
-      <!-- column-name uuid -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
-  <object class="GtkTreeStore" id="readme-treestore">
-    <columns>
-      <!-- column-name key -->
-      <column type="gchararray"/>
-      <!-- column-name value -->
-      <column type="gchararray"/>
-      <!-- column-name is_uuid -->
-      <column type="gboolean"/>
-      <!-- column-name markup -->
-      <column type="gchararray"/>
-    </columns>
   </object>
   <object class="GtkEntryBuffer" id="search-entry-buffer"/>
   <object class="GtkApplicationWindow" id="main-window">
@@ -342,6 +367,7 @@
               <object class="GtkNotebook" id="functionality-notebook">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <signal name="switch-page" handler="on_main_switch_page" swapped="no"/>
                 <child>
                   <object class="GtkStack" id="main-stack">
                     <property name="visible">True</property>
@@ -596,7 +622,7 @@
                                               <object class="GtkTreeView" id="dataset-readme">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">True</property>
-                                                <property name="model">readme-treestore</property>
+                                                <property name="model">lookup-readme-treestore</property>
                                                 <property name="search-column">0</property>
                                                 <property name="enable-tree-lines">True</property>
                                                 <signal name="row-activated" handler="on_readme_row_activated" swapped="no"/>
@@ -738,7 +764,7 @@
                                           <object class="GtkTreeView" id="dataset-manifest">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="model">manifest-treestore</property>
+                                            <property name="model">lookup-manifest-treestore</property>
                                             <property name="search-column">0</property>
                                             <signal name="row-activated" handler="on_manifest_row_activated" swapped="no"/>
                                             <child internal-child="selection">
@@ -927,7 +953,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkPaned">
+                  <object class="GtkPaned" id="direct-view">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <child>
@@ -935,6 +961,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="shadow-type">in</property>
+                        <property name="min-content-width">400</property>
                         <child>
                           <object class="GtkViewport">
                             <property name="visible">True</property>
@@ -943,6 +970,7 @@
                               <object class="GtkListBox" id="dtool-ls-results">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <signal name="row-selected" handler="on_direct_dataset_selected" swapped="no"/>
                               </object>
                             </child>
                           </object>
@@ -1034,7 +1062,431 @@
                           </packing>
                         </child>
                         <child>
-                          <placeholder/>
+                          <object class="GtkNotebook" id="direct-dataset-notebook">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <signal name="switch-page" handler="on_direct_dataset_view_switch_page" swapped="no"/>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <!-- n-columns=3 n-rows=6 -->
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-left">5</property>
+                                    <property name="margin-right">5</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="row-spacing">5</property>
+                                    <property name="column-spacing">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">UUID</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-uuid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">URI</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-uri">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Name</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-name">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Created by</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-created-by">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Created at</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-created-at">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Frozen at</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="direct-dataset-frozen-at">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkStack" id="direct-readme-stack">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkScrolledWindow" id="direct-readme-view">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="shadow-type">in</property>
+                                        <property name="propagate-natural-width">True</property>
+                                        <property name="propagate-natural-height">True</property>
+                                        <child>
+                                          <object class="GtkViewport">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkTreeView" id="direct-dataset-readme">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="model">direct-readme-treestore</property>
+                                                <property name="search-column">0</property>
+                                                <property name="enable-tree-lines">True</property>
+                                                <child internal-child="selection">
+                                                  <object class="GtkTreeSelection"/>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkTreeViewColumn" id="readme-column3">
+                                                    <property name="title" translatable="yes">Key</property>
+                                                    <child>
+                                                      <object class="GtkCellRendererText" id="readme-renderer3"/>
+                                                      <attributes>
+                                                        <attribute name="text">0</attribute>
+                                                      </attributes>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkTreeViewColumn" id="readme-column4">
+                                                    <property name="title" translatable="yes">Value</property>
+                                                    <child>
+                                                      <object class="GtkCellRendererText" id="readme-renderer4">
+                                                        <property name="editable">True</property>
+                                                        <property name="ellipsize">end</property>
+                                                        <property name="wrap-mode">word</property>
+                                                      </object>
+                                                      <attributes>
+                                                        <attribute name="markup">3</attribute>
+                                                      </attributes>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="name">page0</property>
+                                        <property name="title" translatable="yes">page0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinner" id="direct-readme-spinner">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="active">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="name">page1</property>
+                                        <property name="title" translatable="yes">page1</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="menu-label">dataset-readme</property>
+                              </packing>
+                            </child>
+                            <child type="tab">
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Details</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkStack" id="direct-manifest-stack">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkScrolledWindow" id="direct-manifest-view">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="shadow-type">in</property>
+                                    <child>
+                                      <object class="GtkViewport">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkTreeView" id="direct-dataset-manifest">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="model">direct-manifest-treestore</property>
+                                            <property name="search-column">0</property>
+                                            <child internal-child="selection">
+                                              <object class="GtkTreeSelection"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column5">
+                                                <property name="title" translatable="yes">Name</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer5"/>
+                                                  <attributes>
+                                                    <attribute name="text">0</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column6">
+                                                <property name="title" translatable="yes">Size</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer6"/>
+                                                  <attributes>
+                                                    <attribute name="text">1</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column7">
+                                                <property name="title" translatable="yes">Date</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer7"/>
+                                                  <attributes>
+                                                    <attribute name="text">2</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column8">
+                                                <property name="title" translatable="yes">UUID</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer8">
+                                                    <property name="editable">True</property>
+                                                  </object>
+                                                  <attributes>
+                                                    <attribute name="text">3</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="name">page0</property>
+                                    <property name="title" translatable="yes">page0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinner" id="direct-manifest-spinner">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="active">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="name">page1</property>
+                                    <property name="title" translatable="yes">page1</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child type="tab">
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Manifest</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child type="tab">
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
@@ -1051,7 +1503,7 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Manage</property>
+                    <property name="label" translatable="yes">Direct</property>
                   </object>
                   <packing>
                     <property name="position">1</property>

--- a/dtool_lookup_gui/dtool-lookup-gui.glade
+++ b/dtool_lookup_gui/dtool-lookup-gui.glade
@@ -71,6 +71,7 @@
     </child>
   </object>
   <object class="GtkEntryBuffer" id="base-uri-entry-buffer"/>
+  <object class="GtkEntryBuffer" id="dataset-uri-entry-buffer"/>
   <object class="GtkPopover" id="dependency-popover">
     <property name="can-focus">False</property>
     <property name="position">bottom</property>
@@ -946,7 +947,7 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Lookup</property>
+                    <property name="label" translatable="yes">Search</property>
                   </object>
                   <packing>
                     <property name="tab-fill">False</property>
@@ -970,7 +971,7 @@
                               <object class="GtkListBox" id="dtool-ls-results">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <signal name="row-selected" handler="on_direct_dataset_selected" swapped="no"/>
+                                <signal name="row-selected" handler="on_direct_dataset_selected_from_list" swapped="no"/>
                               </object>
                             </child>
                           </object>
@@ -1018,7 +1019,7 @@
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Base URI</property>
+                                <property name="label" translatable="yes">Base URI: </property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
@@ -1041,12 +1042,13 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkButton">
-                                <property name="label">gtk-open</property>
+                              <object class="GtkButton" id="base-uri-apply-button">
+                                <property name="label">gtk-apply</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
                                 <property name="use-stock">True</property>
+                                <property name="always-show-image">True</property>
                                 <signal name="clicked" handler="on_base_uri_open" swapped="no"/>
                               </object>
                               <packing>
@@ -1059,6 +1061,156 @@
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <!-- n-columns=4 n-rows=1 -->
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="row-spacing">5</property>
+                            <property name="column-spacing">5</property>
+                            <child>
+                              <object class="GtkFileChooserButton" id="dataset-uri-chooser-button">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="action">select-folder</property>
+                                <property name="create-folders">False</property>
+                                <property name="local-only">False</property>
+                                <property name="title" translatable="yes"/>
+                                <signal name="file-set" handler="on_dataset_uri_set" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Dataset URI: </property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="dataset-uri-entry">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="buffer">dataset-uri-entry-buffer</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="dataset-uri-apply-button">
+                                <property name="label">gtk-open</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-stock">True</property>
+                                <property name="always-show-image">True</property>
+                                <signal name="clicked" handler="on_dataset_uri_open" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <!-- n-columns=4 n-rows=1 -->
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="row-spacing">5</property>
+                            <property name="column-spacing">5</property>
+                            <property name="column-homogeneous">True</property>
+                            <child>
+                              <object class="GtkButton" id="dtool-create">
+                                <property name="label" translatable="yes">Create dataset</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes">Create new proto dataset at the current base URI, e.g. current local folder.</property>
+                                <property name="always-show-image">True</property>
+                                <signal name="clicked" handler="on_dtool_create" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="dtool-add-items">
+                                <property name="label" translatable="yes">Add items</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="dtool-edit-metadata">
+                                <property name="label" translatable="yes">Edit metadata</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="Freeze dataset">
+                                <property name="label" translatable="yes">Freeze dataset</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes">Freeze the currently selected proto dataset.</property>
+                                <signal name="clicked" handler="on_dtool_freeze" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -1369,6 +1521,9 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Details</property>
                               </object>
+                              <packing>
+                                <property name="tab-fill">False</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkStack" id="direct-manifest-stack">
@@ -1473,6 +1628,7 @@
                               </object>
                               <packing>
                                 <property name="position">1</property>
+                                <property name="tab-fill">False</property>
                               </packing>
                             </child>
                             <child>
@@ -1485,7 +1641,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
@@ -1503,7 +1659,7 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Direct</property>
+                    <property name="label" translatable="yes">Manage</property>
                   </object>
                   <packing>
                     <property name="position">1</property>
@@ -1529,7 +1685,7 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Compare</property>
+                    <property name="label" translatable="yes">Transfer</property>
                   </object>
                   <packing>
                     <property name="position">2</property>

--- a/dtool_lookup_gui/dtool-lookup-gui.glade
+++ b/dtool_lookup_gui/dtool-lookup-gui.glade
@@ -2,6 +2,75 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
+  <object class="GtkWindow">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkHeaderBar">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="title" translatable="yes">Server configuration</property>
+            <property name="show-close-button">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkNotebook">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkTreeView">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
+              </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Users</property>
+              </object>
+              <packing>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Storage</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkEntryBuffer" id="base-uri-entry-buffer"/>
   <object class="GtkPopover" id="dependency-popover">
     <property name="can-focus">False</property>
     <property name="position">bottom</property>
@@ -270,230 +339,323 @@
               </packing>
             </child>
             <child>
-              <object class="GtkStack" id="main-stack">
+              <object class="GtkNotebook" id="functionality-notebook">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <child>
-                  <object class="GtkPaned" id="main-view">
+                  <object class="GtkStack" id="main-stack">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="position">400</property>
+                    <property name="can-focus">False</property>
                     <child>
-                      <object class="GtkScrolledWindow">
+                      <object class="GtkPaned" id="main-view">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="shadow-type">in</property>
-                        <property name="min-content-width">400</property>
+                        <property name="position">400</property>
+                        <property name="position-set">True</property>
                         <child>
-                          <object class="GtkViewport">
+                          <object class="GtkScrolledWindow">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="vscroll-policy">natural</property>
+                            <property name="can-focus">True</property>
+                            <property name="shadow-type">in</property>
+                            <property name="min-content-width">400</property>
                             <child>
-                              <object class="GtkListBox" id="search-results">
+                              <object class="GtkViewport">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <signal name="row-selected" handler="on_result_selected" swapped="no"/>
+                                <property name="vscroll-policy">natural</property>
+                                <child>
+                                  <object class="GtkListBox" id="search-results">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <signal name="row-selected" handler="on_result_selected" swapped="no"/>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="resize">False</property>
+                            <property name="shrink">True</property>
+                          </packing>
                         </child>
-                      </object>
-                      <packing>
-                        <property name="resize">False</property>
-                        <property name="shrink">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkNotebook" id="dataset-notebook">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <signal name="switch-page" handler="on_switch_page" swapped="no"/>
                         <child>
-                          <object class="GtkBox">
+                          <object class="GtkNotebook" id="dataset-notebook">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
+                            <property name="can-focus">True</property>
+                            <signal name="switch-page" handler="on_switch_page" swapped="no"/>
                             <child>
-                              <!-- n-columns=3 n-rows=7 -->
-                              <object class="GtkGrid">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="margin-left">5</property>
-                                <property name="margin-right">5</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="margin-top">5</property>
-                                <property name="margin-bottom">5</property>
                                 <property name="orientation">vertical</property>
-                                <property name="row-spacing">5</property>
-                                <property name="column-spacing">5</property>
                                 <child>
-                                  <object class="GtkLabel">
+                                  <!-- n-columns=3 n-rows=6 -->
+                                  <object class="GtkGrid">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">UUID</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
+                                    <property name="margin-left">5</property>
+                                    <property name="margin-right">5</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="row-spacing">5</property>
+                                    <property name="column-spacing">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">UUID</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-uuid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">URI</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-uri">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Name</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-name">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Created by</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-created-by">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Created at</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-created-at">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Frozen at</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="dataset-frozen-at">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">label</property>
+                                        <property name="selectable">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">5</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">0</property>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="dataset-uuid">
+                                  <object class="GtkStack" id="readme-stack">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
+                                    <child>
+                                      <object class="GtkScrolledWindow" id="readme-view">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="shadow-type">in</property>
+                                        <property name="propagate-natural-width">True</property>
+                                        <property name="propagate-natural-height">True</property>
+                                        <child>
+                                          <object class="GtkViewport">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkTreeView" id="dataset-readme">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="model">readme-treestore</property>
+                                                <property name="search-column">0</property>
+                                                <property name="enable-tree-lines">True</property>
+                                                <signal name="row-activated" handler="on_readme_row_activated" swapped="no"/>
+                                                <child internal-child="selection">
+                                                  <object class="GtkTreeSelection"/>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkTreeViewColumn" id="readme-column1">
+                                                    <property name="title" translatable="yes">Key</property>
+                                                    <child>
+                                                      <object class="GtkCellRendererText" id="readme-renderer1"/>
+                                                      <attributes>
+                                                        <attribute name="text">0</attribute>
+                                                      </attributes>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkTreeViewColumn" id="readme-column2">
+                                                    <property name="title" translatable="yes">Value</property>
+                                                    <child>
+                                                      <object class="GtkCellRendererText" id="readme-renderer2">
+                                                        <property name="editable">True</property>
+                                                        <property name="ellipsize">end</property>
+                                                        <property name="wrap-mode">word</property>
+                                                      </object>
+                                                      <attributes>
+                                                        <attribute name="markup">3</attribute>
+                                                      </attributes>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="name">page0</property>
+                                        <property name="title" translatable="yes">page0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinner" id="readme-spinner">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="active">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="name">page1</property>
+                                        <property name="title" translatable="yes">page1</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">URI</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="dataset-uri">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Name</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="dataset-name">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Created by</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="dataset-created-by">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Created at</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="dataset-created-at">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Frozen at</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">5</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="dataset-frozen-at">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">label</property>
-                                    <property name="selectable">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">5</property>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -546,42 +708,47 @@
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="menu-label">dataset-readme</property>
+                              </packing>
+                            </child>
+                            <child type="tab">
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Details</property>
+                              </object>
+                              <packing>
+                                <property name="tab-fill">False</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkStack" id="readme-stack">
+                              <object class="GtkStack" id="manifest-stack">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <child>
-                                  <object class="GtkScrolledWindow" id="readme-view">
+                                  <object class="GtkScrolledWindow" id="manifest-view">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="shadow-type">in</property>
-                                    <property name="propagate-natural-width">True</property>
-                                    <property name="propagate-natural-height">True</property>
                                     <child>
                                       <object class="GtkViewport">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkTreeView" id="dataset-readme">
+                                          <object class="GtkTreeView" id="dataset-manifest">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="model">readme-treestore</property>
+                                            <property name="model">manifest-treestore</property>
                                             <property name="search-column">0</property>
-                                            <property name="enable-tree-lines">True</property>
-                                            <signal name="row-activated" handler="on_readme_row_activated" swapped="no"/>
+                                            <signal name="row-activated" handler="on_manifest_row_activated" swapped="no"/>
                                             <child internal-child="selection">
                                               <object class="GtkTreeSelection"/>
                                             </child>
                                             <child>
-                                              <object class="GtkTreeViewColumn" id="readme-column1">
-                                                <property name="title" translatable="yes">Key</property>
+                                              <object class="GtkTreeViewColumn" id="manifest-column1">
+                                                <property name="title" translatable="yes">Name</property>
                                                 <child>
-                                                  <object class="GtkCellRendererText" id="readme-renderer1"/>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer1"/>
                                                   <attributes>
                                                     <attribute name="text">0</attribute>
                                                   </attributes>
@@ -589,16 +756,36 @@
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkTreeViewColumn" id="readme-column2">
-                                                <property name="title" translatable="yes">Value</property>
+                                              <object class="GtkTreeViewColumn" id="manifest-column2">
+                                                <property name="title" translatable="yes">Size</property>
                                                 <child>
-                                                  <object class="GtkCellRendererText" id="readme-renderer2">
+                                                  <object class="GtkCellRendererText" id="manifest-renderer2"/>
+                                                  <attributes>
+                                                    <attribute name="text">1</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column3">
+                                                <property name="title" translatable="yes">Date</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer3"/>
+                                                  <attributes>
+                                                    <attribute name="text">2</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="manifest-column4">
+                                                <property name="title" translatable="yes">UUID</property>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="manifest-renderer4">
                                                     <property name="editable">True</property>
-                                                    <property name="ellipsize">end</property>
-                                                    <property name="wrap-mode">word</property>
                                                   </object>
                                                   <attributes>
-                                                    <attribute name="markup">3</attribute>
+                                                    <attribute name="text">3</attribute>
                                                   </attributes>
                                                 </child>
                                               </object>
@@ -614,7 +801,7 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkSpinner" id="readme-spinner">
+                                  <object class="GtkSpinner" id="manifest-spinner">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="active">True</property>
@@ -627,178 +814,227 @@
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
-                          </object>
-                          <packing>
-                            <property name="menu-label">dataset-readme</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Details</property>
-                          </object>
-                          <packing>
-                            <property name="tab-fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkStack" id="manifest-stack">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <child>
-                              <object class="GtkScrolledWindow" id="manifest-view">
+                            <child type="tab">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="shadow-type">in</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Manifest</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                                <property name="tab-fill">False</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkStack" id="dependency-stack">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <child>
-                                  <object class="GtkViewport">
+                                  <object class="GtkBox" id="dependency-view">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkTreeView" id="dataset-manifest">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="model">manifest-treestore</property>
-                                        <property name="search-column">0</property>
-                                        <signal name="row-activated" handler="on_manifest_row_activated" swapped="no"/>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection"/>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="manifest-column1">
-                                            <property name="title" translatable="yes">Name</property>
-                                            <child>
-                                              <object class="GtkCellRendererText" id="manifest-renderer1"/>
-                                              <attributes>
-                                                <attribute name="text">0</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="manifest-column2">
-                                            <property name="title" translatable="yes">Size</property>
-                                            <child>
-                                              <object class="GtkCellRendererText" id="manifest-renderer2"/>
-                                              <attributes>
-                                                <attribute name="text">1</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="manifest-column3">
-                                            <property name="title" translatable="yes">Date</property>
-                                            <child>
-                                              <object class="GtkCellRendererText" id="manifest-renderer3"/>
-                                              <attributes>
-                                                <attribute name="text">2</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="manifest-column4">
-                                            <property name="title" translatable="yes">UUID</property>
-                                            <child>
-                                              <object class="GtkCellRendererText" id="manifest-renderer4">
-                                                <property name="editable">True</property>
-                                              </object>
-                                              <attributes>
-                                                <attribute name="text">3</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                      </object>
+                                      <placeholder/>
                                     </child>
                                   </object>
+                                  <packing>
+                                    <property name="name">page0</property>
+                                    <property name="title" translatable="yes">page0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinner" id="dependency-spinner">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="active">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="name">page1</property>
+                                    <property name="title" translatable="yes">page1</property>
+                                    <property name="position">1</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="name">page0</property>
-                                <property name="title" translatable="yes">page0</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child type="tab">
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Dependencies</property>
+                              </object>
+                              <packing>
+                                <property name="position">2</property>
+                                <property name="tab-fill">False</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="resize">True</property>
+                            <property name="shrink">True</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="name">page3</property>
+                        <property name="title" translatable="yes">page3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinner" id="main-spinner">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="name">page1</property>
+                        <property name="title" translatable="yes">page1</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="main-not-found">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">No datasets found</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="name">page2</property>
+                        <property name="title" translatable="yes">page2</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="tab">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Lookup</property>
+                  </object>
+                  <packing>
+                    <property name="tab-fill">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkPaned">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="shadow-type">in</property>
+                        <child>
+                          <object class="GtkViewport">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkListBox" id="dtool-ls-results">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="resize">False</property>
+                        <property name="shrink">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <!-- n-columns=4 n-rows=1 -->
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="row-spacing">5</property>
+                            <property name="column-spacing">5</property>
+                            <child>
+                              <object class="GtkFileChooserButton" id="base-uri-chooser-button">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="action">select-folder</property>
+                                <property name="create-folders">False</property>
+                                <property name="local-only">False</property>
+                                <property name="title" translatable="yes"/>
+                                <signal name="file-set" handler="on_base_uri_set" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkSpinner" id="manifest-spinner">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="active">True</property>
+                                <property name="label" translatable="yes">Base URI</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
                               </object>
                               <packing>
-                                <property name="name">page1</property>
-                                <property name="title" translatable="yes">page1</property>
-                                <property name="position">1</property>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="base-uri-entry">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="buffer">base-uri-entry-buffer</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton">
+                                <property name="label">gtk-open</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-stock">True</property>
+                                <signal name="clicked" handler="on_base_uri_open" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Manifest</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                            <property name="tab-fill">False</property>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkStack" id="dependency-stack">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <child>
-                              <object class="GtkBox" id="dependency-view">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="name">page0</property>
-                                <property name="title" translatable="yes">page0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSpinner" id="dependency-spinner">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="active">True</property>
-                              </object>
-                              <packing>
-                                <property name="name">page1</property>
-                                <property name="title" translatable="yes">page1</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Dependencies</property>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                            <property name="tab-fill">False</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -808,36 +1044,44 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="name">page3</property>
-                    <property name="title" translatable="yes">page3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinner" id="main-spinner">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="active">True</property>
-                  </object>
-                  <packing>
-                    <property name="name">page1</property>
-                    <property name="title" translatable="yes">page1</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkLabel" id="main-not-found">
+                <child type="tab">
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">No datasets found</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                      <attribute name="scale" value="2"/>
-                    </attributes>
+                    <property name="label" translatable="yes">Manage</property>
                   </object>
                   <packing>
-                    <property name="name">page2</property>
-                    <property name="title" translatable="yes">page2</property>
+                    <property name="position">1</property>
+                    <property name="tab-fill">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkPaned">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child type="tab">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Compare</property>
+                  </object>
+                  <packing>
+                    <property name="position">2</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
               </object>

--- a/dtool_lookup_gui/dtool-lookup-gui.glade
+++ b/dtool_lookup_gui/dtool-lookup-gui.glade
@@ -1169,18 +1169,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkButton" id="dtool-add-items">
-                                <property name="label" translatable="yes">Add items</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkButton" id="dtool-edit-metadata">
                                 <property name="label" translatable="yes">Edit metadata</property>
                                 <property name="visible">True</property>
@@ -1203,6 +1191,19 @@
                               </object>
                               <packing>
                                 <property name="left-attach">3</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="dtool-add-items">
+                                <property name="label" translatable="yes">Add items</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <signal name="clicked" handler="on_dtool_item_add" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>

--- a/dtool_lookup_gui/models.py
+++ b/dtool_lookup_gui/models.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2021 Johannes Hoermann, Lars Pastewka
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+import os
+
+import dtoolcore
+
+from dtool_gui_tk.models import (
+    LocalBaseURIModel,
+    DataSetListModel,
+    DataSetModel,
+    ProtoDataSetModel,
+    MetadataSchemaListModel,
+    UnsupportedTypeError,
+)
+
+
+class BaseURIModel():
+    "Model for managing base URI."
+
+    def __init__(self, base_uri=os.path.curdir):
+        self.put_base_uri(base_uri)
+
+    def get_base_uri(self):
+        """Return the base URI.
+
+        :returns: base URI where datasets will be read from and written to
+        """
+        return self._base_uri
+
+    def put_base_uri(self, base_uri):
+        """Put/update the base URI.
+
+        :param base_uri: base URI
+        """
+        value = dtoolcore.utils.sanitise_uri(base_uri)
+        self._base_uri = value


### PR DESCRIPTION
Rebased on recent item download changes in master.

Introduces "Manage" tab for direct dataset manipulation.

Splits main application into tab-wise modules, i.e. `MainApplication.py`, `LookupTab.py`, `DirectTab.py`.

Partially uses model components from dtool_tk.models (https://github.com/jic-dtool/dtool-gui-tk/blob/master/dtool_gui_tk/models.py).

Missing: dtool cp, dtool readme interactive (metadata editing).

The currently used Base URI enters `dtool.json` config as 

    "DTOOL_LOCAL_BASE_URI": "file://jotelha-fujitsu-ubuntu-20/home/jotelha/dtool/datasets"


