### PR TITLE
2021-11-28 dont open settings dialog twice

### DIFF
--- a/dtool_lookup_gui/__main__.py
+++ b/dtool_lookup_gui/__main__.py
@@ -24,55 +24,5 @@
 #
 
 if __name__ == '__main__':
-    import logging
-    import argparse
-
-    from . import GlobalConfig
     from .MainApplication import run_gui
-
-
-    # in order to have both:
-    # * preformatted help text and ...
-    # * automatic display of defaults
-    class ArgumentDefaultsAndRawDescriptionHelpFormatter(
-        argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-        pass
-
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=ArgumentDefaultsAndRawDescriptionHelpFormatter)
-
-    parser.add_argument('--verbose', '-v', action='count', dest='verbose',
-                        default=0, help='Make terminal output more verbose')
-    parser.add_argument('--all-auto-refresh-off', action='store_true',
-                        dest='all_auto_refresh_off', default=False,
-                        help='Do not load any dataset lists at launch.')
-    parser.add_argument('--debug', action='store_true',
-                        help='Print debug info')
-
-    try:
-        import argcomplete
-        argcomplete.autocomplete(parser)
-    except ModuleNotFoundError as err:
-        pass
-
-    args = parser.parse_args()
-
-    loglevel = logging.ERROR
-
-    if args.verbose > 0:
-        loglevel = logging.WARN
-    if args.verbose > 1:
-        loglevel = logging.INFO
-    if args.debug or (args.verbose > 2):
-        loglevel = logging.DEBUG
-
-    # explicitly modify the root logger
-    logging.basicConfig(level=loglevel)
-    logger = logging.getLogger()
-    logger.setLevel(loglevel)
-
-    if args.all_auto_refresh_off:
-        logger.debug("All auto refresh turned off via CLI flag.")
-        GlobalConfig.auto_refresh_on = False
-
     run_gui()

--- a/dtool_lookup_gui/dtool-lookup-gui.glade
+++ b/dtool_lookup_gui/dtool-lookup-gui.glade
@@ -305,8 +305,8 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
+            <property name="action-name">app.settings</property>
             <property name="text" translatable="yes">Settings</property>
-            <signal name="clicked" handler="on_settings_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -319,6 +319,7 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
+            <property name="action-name">app.about</property>
             <property name="text" translatable="yes">About dtool-lookup-gui</property>
           </object>
           <packing>

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'dtoolcore>=3.17',
         'dtool-create>=0.23.4',
         'dtool-info>=0.16.2',
-        'dtool-lookup-api>=0.3',
+        'dtool-lookup-api>=0.4',
         'aiohttp>=3.6',
         'gbulb>=0.6',
         'pyyaml>=5.3',


### PR DESCRIPTION
When clicking on the "settings" button in the main menu, the settings dialog would always appear twice (at least on my Ubuntu / Gnome system). 

When inspecting the widgets, I noticed that the menu buttons exist twice, once nested within a GtkStack and once not nested,

![image](https://user-images.githubusercontent.com/1868344/143787902-7dc05d11-7ee3-4162-8fcf-d0f9a8420b07.png),

and this apparently results in the "clicked" signal being fired twice.

The glade file does not have this additional GtkStack, the behavior is opaque to me. 

The menu popover tutorial https://python-gtk-3-tutorial.readthedocs.io/en/latest/popover.html#menu-popover works with actions instead. Just as the tutorial, this PR uses actions to display the settings dialog. For this purpose, an explicitly defined `Gtk.Application` class  wraps around the main `SignalHandler` class. 

The command line parsing has been moved from `__main__.py` into this application class as well.

