### PR TITLE
ENH: argument parsing within gtk application

### DIFF
--- a/dtool_lookup_gui/__init__.py
+++ b/dtool_lookup_gui/__init__.py
@@ -41,11 +41,6 @@ import dtoolcore
 logger = logging.getLogger(__name__)
 
 
-class GlobalConfig:
-    """GUI-global behavioral settings. """
-    auto_refresh_on = True
-
-
 @contextmanager
 def time_locale(name):
     # This code snippet was taken from:

--- a/dtool_lookup_gui/__main__.py
+++ b/dtool_lookup_gui/__main__.py
@@ -24,55 +24,5 @@
 #
 
 if __name__ == '__main__':
-    import logging
-    import argparse
-
-    from . import GlobalConfig
     from .main import run_gui
-
-
-    # in order to have both:
-    # * preformatted help text and ...
-    # * automatic display of defaults
-    class ArgumentDefaultsAndRawDescriptionHelpFormatter(
-        argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-        pass
-
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=ArgumentDefaultsAndRawDescriptionHelpFormatter)
-
-    parser.add_argument('--verbose', '-v', action='count', dest='verbose',
-                        default=0, help='Make terminal output more verbose')
-    parser.add_argument('--all-auto-refresh-off', action='store_true',
-                        dest='all_auto_refresh_off', default=False,
-                        help='Do not load any dataset lists at launch.')
-    parser.add_argument('--debug', action='store_true',
-                        help='Print debug info')
-
-    try:
-        import argcomplete
-        argcomplete.autocomplete(parser)
-    except ModuleNotFoundError as err:
-        pass
-
-    args = parser.parse_args()
-
-    loglevel = logging.ERROR
-
-    if args.verbose > 0:
-        loglevel = logging.WARN
-    if args.verbose > 1:
-        loglevel = logging.INFO
-    if args.debug or (args.verbose > 2):
-        loglevel = logging.DEBUG
-
-    # explicitly modify the root logger
-    logging.basicConfig(level=loglevel)
-    logger = logging.getLogger()
-    logger.setLevel(loglevel)
-
-    if args.all_auto_refresh_off:
-        logger.debug("All auto refresh turned off via CLI flag.")
-        GlobalConfig.auto_refresh_on = False
-
     run_gui()

--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -22,7 +22,9 @@
 # SOFTWARE.
 #
 
+import argparse
 import asyncio
+import logging
 import sys
 
 import gi
@@ -42,24 +44,116 @@ import dtool_lookup_gui.widgets.transfer_popover_menu
 import dtool_lookup_gui.widgets.graph_widget
 
 
+logger = logging.getLogger(__name__)
+
+
+# adapted from https://python-gtk-3-tutorial.readthedocs.io/en/latest/popover.html#menu-popover
 class Application(Gtk.Application):
-    def __init__(self):
-        super().__init__(application_id='de.uni-freiburg.dtool-lookup-gui',
-                         flags=Gio.ApplicationFlags.FLAGS_NONE)
+    def __init__(self, *args, loop=None, **kwargs):
+        super().__init__(*args,
+                         application_id='de.uni-freiburg.dtool-lookup-gui',
+                         flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE, **kwargs)
+        self.loop = loop
+        self.args = None
 
     def do_activate(self):
+        logger.debug("do_activate")
         win = self.props.active_window
         if not win:
+            # Windows are associated with the application
+            # when the last one is closed the application shuts down
+            # self.window = AppWindow(application=self, title="Main Window")
+            logger.debug("Build GUI.")
+
             win = MainWindow(application=self)
-        loop = asyncio.get_event_loop()
-        win.connect('destroy', lambda _: loop.stop())
-        loop.call_soon(win.refresh)  # Populate widgets after event loop starts
-        win.show()
-        loop.run_forever()
+            win.connect('destroy', lambda _: self.loop.stop())
+            self.loop.call_soon(win.refresh)  # Populate widgets after event loop starts
+
+        logger.debug("Present main window.")
+        win.present()
+
+    # adapted from http://fedorarules.blogspot.com/2013/09/how-to-handle-command-line-options-in.html
+    # and https://python-gtk-3-tutorial.readthedocs.io/en/latest/application.html#example
+    def do_command_line(self, args):
+        """Handle command line options from within Gtk Application.
+
+        Gtk.Application command line handler called if
+        Gio.ApplicationFlags.HANDLES_COMMAND_LINE set.
+        Must call self.activate() to get the application up and running."""
+
+        Gtk.Application.do_command_line(self, args)  # call the default commandline handler
+
+        # in order to have both:
+        # * preformatted help text and ...
+        # * automatic display of defaults
+        class ArgumentDefaultsAndRawDescriptionHelpFormatter(
+            argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+            pass
+
+        parser = argparse.ArgumentParser(prog=self.get_application_id(),
+                                         description=__doc__,
+                                         formatter_class=ArgumentDefaultsAndRawDescriptionHelpFormatter)
+
+        parser.add_argument('--verbose', '-v', action='count', dest='verbose',
+                            default=0, help='Make terminal output more verbose')
+        parser.add_argument('--debug', action='store_true',
+                            help='Print debug info')
+
+        # parse the command line stored in args, but skip the first element (the filename)
+        self.args = parser.parse_args(args.get_arguments()[1:])
+
+        loglevel = logging.ERROR
+
+        if self.args.verbose > 0:
+            loglevel = logging.WARN
+        if self.args.verbose > 1:
+            loglevel = logging.INFO
+        if self.args.debug or (self.args.verbose > 2):
+            loglevel = logging.DEBUG
+
+        # explicitly modify the root logger
+        logging.basicConfig(level=loglevel)
+        logger = logging.getLogger()
+        logger.setLevel(loglevel)
+        logger = logging.getLogger(__name__) # override global logger after modifying logging settings
+
+        logger.debug("Parsed CLI options {}".format(self.args))
+
+        self.activate()
+        return 0
+
+    def do_startup(self):
+        """Create a few custom actions at application statup, runs before anything else."""
+        logger.debug("do_startup")
+        Gtk.Application.do_startup(self)
+
+    #    action = Gio.SimpleAction(name="settings", parameter_type=None)
+    #    action.connect("activate", self.on_settings)
+    #    self.add_action(action)
+
+    #    action = Gio.SimpleAction(name="about", parameter_type=None)
+    #    action.connect("activate", self.on_about)
+    #    self.add_action(action)
+
+    # action handlers
+    # def on_settings(self, action, param):
+    #    """Open settings dialog."""
+    #    SettingsDialog(self.signal_handler).show()
+
+    # def on_about(self, action, param):
+    #    """Not yet implemented"""
+    #    pass
+
+    # def on_quit(self, action, param):  # not yet used
+    #    self.quit()  # quit the application
 
 
 def run_gui():
     GObject.type_register(GtkSource.View)
 
-    app = Application()
-    return app.run(sys.argv)
+    loop = asyncio.get_event_loop()
+    app = Application(loop=loop)
+    logger.debug("do_startup")
+    # see https://github.com/beeware/gbulb#gapplicationgtkapplication-event-loop
+    loop.run_forever(application=app, argv=sys.argv)
+

--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -123,29 +123,9 @@ class Application(Gtk.Application):
         return 0
 
     def do_startup(self):
-        """Create a few custom actions at application statup, runs before anything else."""
+        """Stub, runs before anything else, create custom actions here."""
         logger.debug("do_startup")
         Gtk.Application.do_startup(self)
-
-    #    action = Gio.SimpleAction(name="settings", parameter_type=None)
-    #    action.connect("activate", self.on_settings)
-    #    self.add_action(action)
-
-    #    action = Gio.SimpleAction(name="about", parameter_type=None)
-    #    action.connect("activate", self.on_about)
-    #    self.add_action(action)
-
-    # action handlers
-    # def on_settings(self, action, param):
-    #    """Open settings dialog."""
-    #    SettingsDialog(self.signal_handler).show()
-
-    # def on_about(self, action, param):
-    #    """Not yet implemented"""
-    #    pass
-
-    # def on_quit(self, action, param):  # not yet used
-    #    self.quit()  # quit the application
 
 
 def run_gui():


### PR DESCRIPTION
* Removes obsolete code from `__init__.py` and `__main__.py`, 
* introduces `do_command_line` and moves CLI argument parsing via `argparse` into `Gtk.Application` (as in https://python-gtk-3-tutorial.readthedocs.io/en/latest/application.html#example)
* introduces `do_startup` for the possibility of custom actions (as another abstraction layer between signals and functionality, as in https://python-gtk-3-tutorial.readthedocs.io/en/latest/popover.html#menu-popover)
* moves `asyncio` event loop out of `Gtk.Application` (necessary for implementing the above and suggested for explicitly defined Gtk applications, https://github.com/beeware/gbulb#gapplicationgtkapplication-event-loop)

In short, reintroduces some useful bits of https://github.com/IMTEK-Simulation/dtool-lookup-gui/pull/41. 