### PR TITLE
2021/12/11 Multiprocessing

### DIFF
--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -187,7 +187,9 @@ async def _copy_dataset(uri, target_base_uri, resume, auto_resume):
                 raise FileExistsError(
                     "Path already exists: {}".format(parsed_dataset_uri.path))
 
-    def copy_func_wrapper(src_uri, dest_base_uri, status_report_callback, stop_event_callback):
+    num_items = len(list(dataset.identifiers))
+
+    def copy_func_wrapper(src_uri, dest_base_uri, status_report_callback):
         copy_func(
             src_uri=src_uri,
             dest_base_uri=dest_base_uri,
@@ -195,14 +197,11 @@ async def _copy_dataset(uri, target_base_uri, resume, auto_resume):
             progressbar=status_report_callback,
         )
 
-    num_items = len(list(dataset.identifiers))
-
     with ProgressBar(length=num_items * 2,
                      label="Copying dataset",
                      pb=None) as progressbar:
         non_blocking_copy_func = StatusReportingChildProcessBuilder(copy_func_wrapper, progressbar)
         dest_uri = await non_blocking_copy_func(uri, target_base_uri)
-
 
     logger.info(f'Dataset successfully copied from {uri} to {target_base_uri}.')
 

--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -160,7 +160,7 @@ def _load_dataset(uri):
     return dataset
 
 
-def _copy_dataset(uri, target_base_uri, resume, auto_resume):
+async def _copy_dataset(uri, target_base_uri, resume, auto_resume):
     logger.info(f'Copying dataset from URI {uri} to {target_base_uri}...')
 
     dataset = _load_dataset(uri)
@@ -201,7 +201,7 @@ def _copy_dataset(uri, target_base_uri, resume, auto_resume):
                      label="Copying dataset",
                      pb=None) as progressbar:
         non_blocking_copy_func = StatusReportingChildProcessBuilder(copy_func_wrapper, progressbar)
-        dest_uri = non_blocking_copy_func(uri, target_base_uri)
+        dest_uri = await non_blocking_copy_func(uri, target_base_uri)
 
 
     logger.info(f'Dataset successfully copied from {uri} to {target_base_uri}.')
@@ -298,10 +298,7 @@ class DatasetModel:
 
     async def copy(self, target_base_uri, resume=False, auto_resume=True, progressbar=None):
         """Copy a dataset."""
-
-        loop = asyncio.get_running_loop()
-        with ProcessPoolExecutor(1) as executor:
-            return await loop.run_in_executor(executor, _copy_dataset, self.uri, target_base_uri, resume, auto_resume)
+        await _copy_dataset(self.uri, target_base_uri, resume, auto_resume)
 
     def freeze(self):
         _load_dataset(str(self)).freeze()

--- a/dtool_lookup_gui/utils/multiprocessing.py
+++ b/dtool_lookup_gui/utils/multiprocessing.py
@@ -1,0 +1,160 @@
+#
+# Copyright 2021 Johanns Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Multiprocessing utils."""
+
+# NOTE: depending on platform, we may have to experiment with the forking methods,
+# https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+
+import logging
+import multiprocessing  # run task as child process to avoid side effects
+import queue
+import traceback  # forward exception from child process to parent process
+
+
+logger = logging.getLogger(__name__)
+
+
+# inspired by
+# https://stackoverflow.com/questions/19924104/python-multiprocessing-handling-child-errors-in-parent
+class Process(multiprocessing.Process):
+    """
+    Class which returns child Exceptions to Parent.
+    https://stackoverflow.com/a/33599967/4992248
+    """
+
+    def __init__(self, *args, **kwargs):
+        multiprocessing.Process.__init__(self, *args, **kwargs)
+        self._parent_conn, self._child_conn = multiprocessing.Pipe()
+        self._exception = None
+
+    def run(self):
+        try:
+            super().run()
+            self._child_conn.send(None)
+        except Exception as e:
+            tb = traceback.format_exc()
+            self._child_conn.send((e, tb))
+            raise e  # You can still rise this exception if you need to
+
+    @property
+    def exception(self):
+        if self._parent_conn.poll():
+            self._exception = self._parent_conn.recv()
+        return self._exception
+
+
+class StatusReportingChildProcessBuilder:
+    """Outsource serial functions with status report callbacks.
+
+    For any function that runs serial and reports status via a callback, this
+    wrapper can run them in a forked process and forward the status reports
+    via queue to the callback.
+
+    The function must have the signature
+
+        func(*args, status_report_callback=None, stop_event_callback=None)
+
+    and need not make use of any of the two callback functions. It can check on
+    the stop_event_callback() to finish gracefully when the parent process wants
+    the child process to finish.
+    """
+    def __init__(self, target, status_report_callback):
+        self._target = target
+        self._status_report_handler = status_report_callback
+
+    def __call__(self, *args):
+        """Spawn child process to assure my environment stays untouched."""
+        return_value_queue = multiprocessing.Queue()
+        status_progress_queue = multiprocessing.Queue()
+        stop_event = multiprocessing.Event()
+        process = Process(target=self.target_wrapper, args=[return_value_queue, status_progress_queue, stop_event, *args])
+        process.start()
+
+        # wait for child to queue objects and
+        # check whether child raises exception
+        while return_value_queue.empty():
+            # if child raises exception, then it has terminated
+            # before queueing any fw_action object
+            if process.exception:
+                error, p_traceback = process.exception
+                raise ChildProcessError(p_traceback)
+
+            try:
+                status_report = status_progress_queue.get_nowait()
+            except queue.Empty:
+                pass
+            else:
+                logger.debug(f"Parent process received status report {status_report}")
+                self._status_report_handler(status_report)
+
+            # let child process stop
+            if hasattr(self, '_stop_event') and hasattr(self._stop_event, 'is_set'):
+                if self._stop_event.is_set():
+                    stop_event.set()
+
+        # this loop will deadlock for any child that never raises
+        # an exception and does not queue anything
+
+        # queue only used for one transfer of
+        # return fw_action, should thus never deadlock.
+        return_value = return_value_queue.get()
+        # if we reach this line without the child
+        # queueing anything, then process will deadlock.
+        process.join()
+        return return_value
+
+    def target_wrapper(self, return_value_queue, status_progress_queue, stop_event, *args):
+
+        def status_report_callback(status_report):
+            logger.debug(f"Child process queues status report {status_report}")
+            status_progress_queue.put(status_report)
+
+        def stop_event_callback():
+            logger.debug(f"Child process checks stop event.")
+            return stop_event.is_set()
+
+        return_value_queue.put(self._target(*args, status_report_callback=status_report_callback, stop_event_callback=stop_event_callback))
+
+    def set_stop_event(self, e):
+        self._stop_event = e
+
+
+def test_function(steps, status_report_callback, stop_event_callback=None):
+    for n in range(steps):
+        print(f"Child process step {n}")
+        status_report_callback(n)
+        if stop_event_callback is not None and stop_event_callback():
+            return False
+
+    return True
+
+
+def test_callback(n):
+    print(f"Test callback received report for step {n}")
+
+
+def test_run():
+    test_process = StatusReportingChildProcessBuilder(test_function, test_callback)
+    return_value = test_process(10)
+    print(f"Child process returned {return_value}.")

--- a/dtool_lookup_gui/utils/multiprocessing.py
+++ b/dtool_lookup_gui/utils/multiprocessing.py
@@ -142,6 +142,7 @@ class StatusReportingChildProcessBuilder:
         return_value_queue.put(self._target(*args, status_report_callback=StatusReportClass, stop_event_callback=stop_event_callback))
 
     def set_stop_event(self, e):
+        """This can be a threaded event and will be forwarded to the child process."""
         self._stop_event = e
 
 
@@ -155,11 +156,12 @@ def test_function(steps, status_report_callback, stop_event_callback=None):
     return True
 
 
-def test_callback(n):
-    print(f"Test callback received report for step {n}")
+class test_handler:
+    def update(n):
+        print(f"Test callback received report for step {n}")
 
 
 def test_run():
-    test_process = StatusReportingChildProcessBuilder(test_function, test_callback)
+    test_process = StatusReportingChildProcessBuilder(test_function, test_handler)
     return_value = test_process(10)
     print(f"Child process returned {return_value}.")

--- a/dtool_lookup_gui/utils/multiprocessing.py
+++ b/dtool_lookup_gui/utils/multiprocessing.py
@@ -26,6 +26,7 @@
 # NOTE: depending on platform, we may have to experiment with the forking methods,
 # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
 
+import asyncio
 import logging
 import multiprocessing  # run task as child process to avoid side effects
 import queue
@@ -87,7 +88,7 @@ class StatusReportingChildProcessBuilder:
         self._target = target
         self._status_report_handler = status_report_callback
 
-    def __call__(self, *args):
+    async def __call__(self, *args):
         """Spawn child process to assure my environment stays untouched."""
         return_value_queue = multiprocessing.Queue()
         status_progress_queue = multiprocessing.Queue()
@@ -117,6 +118,7 @@ class StatusReportingChildProcessBuilder:
                 if self._stop_event.is_set():
                     stop_event.set()
 
+            await asyncio.sleep(0.1)
         # this loop will deadlock for any child that never raises
         # an exception and does not queue anything
 
@@ -161,7 +163,7 @@ class test_handler:
         print(f"Test callback received report for step {n}")
 
 
-def test_run():
+async def test_run():
     test_process = StatusReportingChildProcessBuilder(test_function, test_handler)
-    return_value = test_process(10)
+    return_value = await test_process(10)
     print(f"Child process returned {return_value}.")

--- a/dtool_lookup_gui/utils/progressbar.py
+++ b/dtool_lookup_gui/utils/progressbar.py
@@ -1,0 +1,101 @@
+#
+# Copyright 2021 Johanns Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Progressbar"""
+import logging
+
+from gi.repository import Gtk
+
+from contextlib import AbstractContextManager
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressBar(AbstractContextManager):
+    """Mimics click.progressbar". Just log messages if no progressbar specified."""
+    def __init__(self, length=None, label=None,
+                 pb: Optional[Gtk.ProgressBar] = None):
+        # if pb is None:
+        #    pb = Gtk.ProgressBar(show_text=True, text=None)
+        self._pb = pb
+        self._item_show_func = None
+        self._label_template = '{label:}'
+        self._label_item_template = '{label:} ({item:})'
+        self._label = label
+        self._length = length
+        self._step = 0
+
+    def __enter__(self):
+        if self._pb is not None:
+            self._pb.set_fraction(0.0)
+        logger.info(f"Progress fraction 0.0")
+        self._set_text()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return
+
+    @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        self._label = label
+        self._set_text()
+
+    @property
+    def item_show_func(self):
+        return self._item_show_func
+
+    @item_show_func.setter
+    def item_show_func(self, item_show_func):
+        self._item_show_func = item_show_func
+        self._set_text()
+
+    def update(self, step):
+        self._step += step
+        fraction = float(self._step) / float(self._length)
+        if self._pb is not None:
+            self._pb.set_fraction(fraction)
+        logger.info(f"Progress fraction {fraction}")
+        self._set_text()
+
+    def _set_text(self):
+        if self._label is not None and self._item_show_func is not None:
+            text = self._label_item_template.format(
+                label=self._label, item=self.item_show_func(self._step))
+            if self._pb is not None:
+                self._pb.set_text(text)
+        if self._label is not None:
+            text = self._label_template.format(label=self._label)
+            if self._pb is not None:
+                self._pb.set_text(text)
+        else:
+            text = None
+            if self._pb is not None:
+                self._pb.set_show_text(False)
+
+        if text is not None:
+            logger.info(text)

--- a/dtool_lookup_gui/views/main_window.py
+++ b/dtool_lookup_gui/views/main_window.py
@@ -61,6 +61,8 @@ _logger = logging.getLogger(__name__)
 def _fill_manifest_tree_store(store, manifest, parent=None):
     nodes = {}
 
+    store.clear()
+
     def find_or_create_parent_node(path, top_parent):
         if not path:
             return top_parent
@@ -128,8 +130,15 @@ class MainWindow(Gtk.ApplicationWindow):
     dependency_graph_widget = Gtk.Template.Child()
 
     readme_source_view = Gtk.Template.Child()
+    readme_spinner = Gtk.Template.Child()
+    readme_stack = Gtk.Template.Child()
+    readme_view = Gtk.Template.Child()
+
+    manifest_spinner = Gtk.Template.Child()
+    manifest_stack = Gtk.Template.Child()
     manifest_tree_view = Gtk.Template.Child()
     manifest_tree_store = Gtk.Template.Child()
+    manifest_view = Gtk.Template.Child()
 
     settings_button = Gtk.Template.Child()
 
@@ -516,9 +525,15 @@ class MainWindow(Gtk.ApplicationWindow):
             self.copy_button.set_sensitive(True)
 
         async def _get_readme():
+            self.readme_stack.set_visible_child(self.readme_spinner)
             self.readme_buffer.set_text(await dataset.get_readme())
+            self.readme_stack.set_visible_child(self.readme_view)
+
         async def _get_manifest():
+            self.manifest_stack.set_visible_child(self.manifest_spinner)
             _fill_manifest_tree_store(self.manifest_tree_store, await dataset.get_manifest())
+            self.manifest_stack.set_visible_child(self.manifest_view)
+
         asyncio.create_task(_get_readme())
         asyncio.create_task(_get_manifest())
 

--- a/dtool_lookup_gui/views/main_window.ui
+++ b/dtool_lookup_gui/views/main_window.ui
@@ -342,7 +342,7 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkNotebook" id="dataset-notebook">
+                                  <object class="GtkNotebook" id="dataset_notebook">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="vexpand">True</property>
@@ -561,20 +561,20 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkStack" id="readme-stack">
+                                          <object class="GtkStack" id="readme_stack">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="vexpand">True</property>
                                             <child>
-                                              <object class="GtkBox">
+                                              <object class="GtkBox" id="readme_view">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="vexpand">True</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
-                                                  <object class="GtkScrolledWindow" id="readme-view">
+                                                  <object class="GtkScrolledWindow">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">True</property>
                                                     <property name="hexpand">True</property>
@@ -680,7 +680,7 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkSpinner" id="readme-spinner">
+                                              <object class="GtkSpinner" id="readme_spinner">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="active">True</property>
@@ -718,7 +718,7 @@
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkScrolledWindow" id="manifest-view">
+                                          <object class="GtkScrolledWindow" id="manifest_view">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="shadow-type">in</property>
@@ -793,7 +793,7 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinner" id="manifest-spinner">
+                                          <object class="GtkSpinner" id="manifest_spinner">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="active">True</property>


### PR DESCRIPTION
This outsources the dtool API's copy function to another process and receives status updates. The mock utils.processbar.ProcessBar replaces the click.ProcessBar expected by dtoolcore. Right now, only prints log messages. Should be directly attachable to a Gtk.ProgressBar. The utils.muliprocessing utility module needs a bit of cleaning up.

For a simple demonstration, 

```python
from dtool_lookup_gui.utils.multiprocessing import test_run
test_run()
```

will produce output like

```
Child process step 0
Child process step 1
Child process step 2
Child process step 3
Test callback received report for step 0
Test callback received report for step 1
Child process step 4
Child process step 5
Test callback received report for step 2
Child process step 6
Test callback received report for step 3
Child process step 7
Test callback received report for step 4
Child process step 8
Test callback received report for step 5
Child process step 9
Test callback received report for step 6
Test callback received report for step 7
Test callback received report for step 8
Test callback received report for step 9
Child process returned True.
```