### PR TITLE
Custom cairo pyinstaller hook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,24 @@ from within this repository. :code:`$GITHUB_TOKEN` must hold a valid
 `access token <https://github.com/settings/tokens>`_.
 The evoking user must be member of the :code:`docker` group.
 
+To generate a pyinstaller-packaged application by the according workflow and 
+store it locally, use the ``--bind`` flag, i.e.
+
+.. code-block:: bash
+
+  act -s GITHUB_TOKEN=$GITHUB_TOKEN -W .github/workflows/build-on-ubuntu.yml --bind
+
+This will bind-mount the current folder into the workflow-executing container.
+All locally generated artifacts will hence survive the container's lifespan,
+but usually belong to ``root``. The executable resides below ``dist``. Use 
+
+.. code-block:: bash
+
+   sudo chown -R $USER:$USER .
+   git clean -fdx
+
+to remove the generated ``build``, ``dist``, and ``workflow`` folders and all other artifacts.
+
 
 GUI design
 ^^^^^^^^^^

--- a/pyinstaller/dtool-lookup-gui-debug.spec
+++ b/pyinstaller/dtool-lookup-gui-debug.spec
@@ -13,6 +13,8 @@ for module in dtool_hidden_imports:
 
 dtool_storage_brokers_datas, dtool_storage_brokers_hidden_imports = collect_entry_point("dtool.storage_brokers")
 
+other_hidden_imports = ['cairo']
+
 # relative to repository root
 glob_patterns_to_include =  [
     'README.rst', 'LICENSE.md',
@@ -26,7 +28,9 @@ additional_datas = [
      os.path.join(os.curdir, os.path.dirname(rel_path))) for rel_path in glob_patterns_to_include
 ]
 
-runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
+hooks_path = [os.path.join(root_dir, 'pyinstaller/hooks')]
+
+runtime_hooks = [os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
@@ -37,8 +41,12 @@ a = Analysis(
         *dtool_storage_brokers_datas,
         *dtool_hidden_imports_datas,
     ],
-    hiddenimports=[*dtool_hidden_imports, *dtool_storage_brokers_hidden_imports],
-    hookspath=[],
+    hiddenimports=[
+      *dtool_hidden_imports,
+      *dtool_storage_brokers_hidden_imports,
+      *other_hidden_imports,
+    ],
+    hookspath=[*hooks_path],
     hooksconfig={
         "gi": {
             "icons": ["Adwaita"],

--- a/pyinstaller/dtool-lookup-gui-debug.spec
+++ b/pyinstaller/dtool-lookup-gui-debug.spec
@@ -28,13 +28,9 @@ additional_datas = [
 
 runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
-python_path = [
-  '/home/jotelha/venv/20220120-dtool-lookup-gui/lib/python3.8/site-packages'
-]
-
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
-    pathex=[*python_path],
+    pathex=[],
     binaries=[],
     datas=[
         *additional_datas,

--- a/pyinstaller/dtool-lookup-gui-one-file.spec
+++ b/pyinstaller/dtool-lookup-gui-one-file.spec
@@ -13,6 +13,8 @@ for module in dtool_hidden_imports:
 
 dtool_storage_brokers_datas, dtool_storage_brokers_hidden_imports = collect_entry_point("dtool.storage_brokers")
 
+other_hidden_imports = ['cairo']
+
 # relative to repository root
 glob_patterns_to_include =  [
     'README.rst', 'LICENSE.md',
@@ -26,7 +28,9 @@ additional_datas = [
      os.path.join(os.curdir, os.path.dirname(rel_path))) for rel_path in glob_patterns_to_include
 ]
 
-runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
+hooks_path = [os.path.join(root_dir, 'pyinstaller/hooks')]
+
+runtime_hooks = [os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
@@ -37,8 +41,12 @@ a = Analysis(
         *dtool_storage_brokers_datas,
         *dtool_hidden_imports_datas,
     ],
-    hiddenimports=[*dtool_hidden_imports, *dtool_storage_brokers_hidden_imports],
-    hookspath=[],
+    hiddenimports=[
+      *dtool_hidden_imports,
+      *dtool_storage_brokers_hidden_imports,
+      *other_hidden_imports,
+    ],
+    hookspath=[*hooks_path],
     hooksconfig={
         "gi": {
             "icons": ["Adwaita"],

--- a/pyinstaller/dtool-lookup-gui-one-file.spec
+++ b/pyinstaller/dtool-lookup-gui-one-file.spec
@@ -28,13 +28,9 @@ additional_datas = [
 
 runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
-python_path = [
-  '/home/jotelha/venv/20220120-dtool-lookup-gui/lib/python3.8/site-packages'
-]
-
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
-    pathex=[*python_path],
+    pathex=[],
     binaries=[],
     datas=[
         *additional_datas,

--- a/pyinstaller/dtool-lookup-gui.spec
+++ b/pyinstaller/dtool-lookup-gui.spec
@@ -13,6 +13,8 @@ for module in dtool_hidden_imports:
 
 dtool_storage_brokers_datas, dtool_storage_brokers_hidden_imports = collect_entry_point("dtool.storage_brokers")
 
+other_hidden_imports = ['cairo']
+
 # relative to repository root
 glob_patterns_to_include =  [
     'README.rst', 'LICENSE.md',
@@ -26,7 +28,9 @@ additional_datas = [
      os.path.join(os.curdir, os.path.dirname(rel_path))) for rel_path in glob_patterns_to_include
 ]
 
-runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
+hooks_path = [os.path.join(root_dir, 'pyinstaller/hooks')]
+
+runtime_hooks = [os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
@@ -37,8 +41,12 @@ a = Analysis(
         *dtool_storage_brokers_datas,
         *dtool_hidden_imports_datas,
     ],
-    hiddenimports=[*dtool_hidden_imports, *dtool_storage_brokers_hidden_imports],
-    hookspath=[],
+    hiddenimports=[
+      *dtool_hidden_imports,
+      *dtool_storage_brokers_hidden_imports,
+      *other_hidden_imports,
+    ],
+    hookspath=[*hooks_path],
     hooksconfig={
         "gi": {
             "icons": ["Adwaita"],

--- a/pyinstaller/dtool-lookup-gui.spec
+++ b/pyinstaller/dtool-lookup-gui.spec
@@ -28,13 +28,9 @@ additional_datas = [
 
 runtime_hooks=[os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py')]
 
-python_path = [
-  '/home/jotelha/venv/20220120-dtool-lookup-gui/lib/python3.8/site-packages'
-]
-
 a = Analysis(
     [os.path.join(root_dir, 'dtool_lookup_gui', 'launcher.py')],
-    pathex=[*python_path],
+    pathex=[],
     binaries=[],
     datas=[
         *additional_datas,

--- a/pyinstaller/hooks/hook-cairo.py
+++ b/pyinstaller/hooks/hook-cairo.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_all
+
+datas, binaries, hiddenimports = collect_all('cairo')


### PR DESCRIPTION
Custom cairo pyinstaller hook fixes `TypeError: Couldn't find foreign struct converter for 'cairo.Context'` (https://github.com/IMTEK-Simulation/dtool-lookup-gui/pull/64#issuecomment-1018416997) 
