### PR TITLE
2022-02-02 Search for reason behind frequent GUI freezing

### DIFF
--- a/dtool_lookup_gui/models/simple_graph.py
+++ b/dtool_lookup_gui/models/simple_graph.py
@@ -268,8 +268,8 @@ class GraphLayout:
                     action = 'mix'
 
             it += 1
-            logger.debug(f'FIRE: {action}, '
-                         f'energy: {self._energy}, '
-                         f'(old energy: {old_energy}, '
-                         f'max |force|: {np.sqrt(np.max(np.sum(self._forces ** 2, axis=1)))},'
-                         f' timestep: {self.timestep}')
+            # logger.debug(f'FIRE: {action}, '
+            #             f'energy: {self._energy}, '
+            #             f'(old energy: {old_energy}, '
+            #             f'max |force|: {np.sqrt(np.max(np.sum(self._forces ** 2, axis=1)))},'
+            #             f' timestep: {self.timestep}')

--- a/dtool_lookup_gui/utils/dependency_graph.py
+++ b/dtool_lookup_gui/utils/dependency_graph.py
@@ -53,6 +53,7 @@ class DependencyGraph:
 
     async def trace_dependencies(self, lookup, root_uuid, dependency_keys=None):
         """Build dependency graph by UUID."""
+        logger.debug(f"Build dependency graph for root '{root_uuid}'.")
         self._reset_graph()
 
         if isinstance(dependency_keys, str):
@@ -71,6 +72,7 @@ class DependencyGraph:
             # and this field is unique:
             uuid = dataset['uuid']
             if 'uuid' in dataset and uuid not in self._uuid_to_vertex:
+                logger.debug(f"Add dependency graph vertex '{uuid}'.")
                 v = self._graph.add_vertex(
                     uuid=uuid,
                     name=dataset['name'],
@@ -83,6 +85,7 @@ class DependencyGraph:
                     if is_uuid(parent_uuid):
                         if parent_uuid not in self._uuid_to_vertex:
                             # This UUID is present in the graph but not in the database
+                            logger.debug(f"Add dependency graph vertex of missing dataset '{parent_uuid}'.")
                             v = self._graph.add_vertex(
                                 uuid=parent_uuid,
                                 name='Dataset does not exist in database.',
@@ -90,6 +93,7 @@ class DependencyGraph:
                             self._uuid_to_vertex[parent_uuid] = v
                             self._missing_uuids += [parent_uuid]
 
+                        logger.debug(f"Add dependency graph edge between child '{dataset['uuid']}' and parent {parent_uuid}.")
                         self._graph.add_edge(
                             self._uuid_to_vertex[dataset['uuid']],
                             self._uuid_to_vertex[parent_uuid])
@@ -99,6 +103,9 @@ class DependencyGraph:
                             "valid UUID, ignored.".format(parent_uuid,
                                                           dataset['uuid'],
                                                           dataset['name']))
+        logger.debug(f"Done building dependency graph for root '{root_uuid}'.")
+
+
 
     @property
     def missing_uuids(self):

--- a/dtool_lookup_gui/views/main_window.py
+++ b/dtool_lookup_gui/views/main_window.py
@@ -657,11 +657,13 @@ class MainWindow(Gtk.ApplicationWindow):
         self.copy_button.get_popover().update(destinations, self.on_copy_clicked)
 
     async def _compute_dependencies(self, dataset):
+        _logger.debug("Compute dependencies for dataset '{dataset.uuid}'.")
         self.dependency_stack.set_visible_child(self.dependency_spinner)
 
         # Compute dependency graph
         dependency_graph = DependencyGraph()
         async with ConfigurationBasedLookupClient() as lookup:
+            _logger.debug("Wait for depenedency graph for '{dataset.uuid}' queried from lookup server.")
             await dependency_graph.trace_dependencies(lookup, dataset.uuid, dependency_keys=settings.dependency_keys)
 
         # Show message if uuids are missing

--- a/dtool_lookup_gui/widgets/graph_widget.py
+++ b/dtool_lookup_gui/widgets/graph_widget.py
@@ -40,6 +40,10 @@ from .graph_popover import DtoolGraphPopover
 
 logger = logging.getLogger(__name__)
 
+# with a timeout of 10 microseconds, GUI freezes regularly on my machine (Ubuntu 20.04)
+TIMEOUT = 50
+
+
 def circle(context, x, y):
     context.arc(x, y, 0.5, 0, 2 * pi)
     context.close_path()
@@ -94,7 +98,7 @@ class DtoolGraphWidget(Gtk.DrawingArea):
         self._graph.set_vertex_properties('state', np.zeros(self._graph.nb_vertices, dtype=bool))
         self._layout = GraphLayout(self._graph)
         if self._timer is None:
-            self._timer = GObject.timeout_add(10, self.on_timeout, self)
+            self._timer = GObject.timeout_add(TIMEOUT, self.on_timeout, self)
 
     def __del__(self):
         if self._timer is not None:


### PR DESCRIPTION
A timeout of 10 microseconds resulted in the Gtk GUI to freeze frequently when opening the dependency graph tab. An increased timeout alleviated the issue on my machine. 