### PR TITLE
2022 02 02 more hardening: multiprocessing on Windows

### DIFF
--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -23,6 +23,9 @@
 # SOFTWARE.
 #
 
+# the following import is necessary to patch flawed dtoolcore.utils function
+import dtool_lookup_gui.utils.patch
+
 import argparse
 import asyncio
 import logging
@@ -45,6 +48,7 @@ import dtool_lookup_gui.widgets.graph_widget
 import dtool_lookup_gui.widgets.transfer_popover_menu
 import dtool_lookup_gui.widgets.progress_chart
 import dtool_lookup_gui.widgets.progress_popover_menu
+
 
 
 logger = logging.getLogger(__name__)

--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -128,11 +128,13 @@ class Application(Gtk.Application):
         if self.args.verbose > 0:
             loglevel = logging.INFO
         if self.args.debug or (self.args.verbose > 1):
+            loglevel = logging.DEBUG
+
+        if self.args.verbose > 2:
             logformat = (
-                "[%(asctime)s - %(funcName)s - %(filename)s:%(lineno)s]"
+                "[%(asctime)s - pid %(process)d - thread id %(thread)d - %(funcName)s - %(pathname)s:%(lineno)s]"
                 " %(levelname)s: %(message)s"
             )
-            loglevel = logging.DEBUG
 
         # explicitly modify the root logger
         logging.basicConfig(level=loglevel, format=logformat)

--- a/dtool_lookup_gui/models/base_uris.py
+++ b/dtool_lookup_gui/models/base_uris.py
@@ -23,6 +23,8 @@
 # SOFTWARE.
 #
 
+import logging
+
 from io import StringIO
 
 from ruamel.yaml import YAML
@@ -35,6 +37,9 @@ from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient
 
 from .datasets import DatasetModel
 from .settings import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class BaseURI:
@@ -75,7 +80,9 @@ class LocalBaseURIModel(BaseURI):
 
     @classmethod
     def add_directory(cls, path):
+        logger.debug(f"Add local path {path} as base URI.")
         base_uri = generous_parse_uri(path)
+        logger.debug(f"Parsed to qualified base URI {base_uri}.")
         if base_uri.scheme != cls._scheme:
             raise ValueError(f"The URI provided specified schema '{base_uri.scheme}', but this base URI model "
                              f"supports '{cls._scheme}'.")
@@ -110,9 +117,11 @@ class LocalBaseURIModel(BaseURI):
         admin_metadata = generate_admin_metadata(name)
 
         # Create the dataset
+        base_uri = f'{self.scheme}:{self.uri_name}'
+        logger.debug(f"Create dataset {name} at base URI {base_uri}.")
         proto_dataset = generate_proto_dataset(
             admin_metadata=admin_metadata,
-            base_uri=f'{self.scheme}:{self.uri_name}')
+            base_uri=base_uri)
         proto_dataset.create()  # May raise StorageBrokerOSError
 
         # Initialize with template README.yml

--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -26,6 +26,7 @@
 import asyncio
 import logging
 import os
+
 import yaml
 from concurrent.futures import ProcessPoolExecutor
 
@@ -36,9 +37,8 @@ from dtool_info.utils import date_fmt, sizeof_fmt
 from dtool_info.inventory import _dataset_info
 from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient
 
-from ..utils.multiprocessing import StatusReportingChildProcessBuilder
+from ..utils.multiprocessing import StatusReportingChildProcessBuilder, process_initializer
 from ..utils.progressbar import ProgressBar
-
 
 
 logger = logging.getLogger(__name__)
@@ -231,7 +231,7 @@ class DatasetModel:
 
         loop = asyncio.get_running_loop()
         datasets = []
-        with ProcessPoolExecutor(2) as executor:
+        with ProcessPoolExecutor(max_workers=2, initializer=process_initializer) as executor:
             datasets += await loop.run_in_executor(executor, _list_proto_datasets, base_uri)
             datasets += await loop.run_in_executor(executor, _list_datasets, base_uri)
 

--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -44,6 +44,20 @@ from ..utils.progressbar import ProgressBar
 logger = logging.getLogger(__name__)
 
 
+class CopyFuncWrapper:
+    def __init__(self, copy_func):
+        self._copy_func = copy_func
+
+    def __call__(self, src_uri, dest_base_uri, status_report_callback):
+        """Wraps a dtool copy_func into interface compatible with StatusReportingChildProcessBuilder"""
+        self._copy_func(
+            src_uri=src_uri,
+            dest_base_uri=dest_base_uri,
+            config_path=None,
+            progressbar=status_report_callback,
+        )
+
+
 def _proto_dataset_info(dataset):
     """Return information about proto dataset as a dict."""
     # Analogous to dtool_info.inventory._dataset_info
@@ -190,13 +204,7 @@ async def _copy_dataset(uri, target_base_uri, resume, auto_resume, progressbar=N
 
     num_items = len(list(dataset.identifiers))
 
-    def copy_func_wrapper(src_uri, dest_base_uri, status_report_callback):
-        copy_func(
-            src_uri=src_uri,
-            dest_base_uri=dest_base_uri,
-            config_path=None,
-            progressbar=status_report_callback,
-        )
+    copy_func_wrapper = CopyFuncWrapper(copy_func)
 
     with ProgressBar(length=num_items,
                      label="Copying dataset",

--- a/dtool_lookup_gui/utils/copy_manager.py
+++ b/dtool_lookup_gui/utils/copy_manager.py
@@ -50,4 +50,7 @@ class CopyManager:
         # Refresh pie chart
         total_length = sum([len(tracker) for tracker in self._progress_popover.status_boxes])
         total_step = sum([tracker.step for tracker in self._progress_popover.status_boxes])
-        self._progress_chart.set_fraction(total_step / total_length)
+        if total_length > 0:
+            self._progress_chart.set_fraction(total_step / total_length)
+        else:
+            self._progress_chart.set_fraction(1.)

--- a/dtool_lookup_gui/utils/multiprocessing.py
+++ b/dtool_lookup_gui/utils/multiprocessing.py
@@ -36,6 +36,20 @@ import traceback  # forward exception from child process to parent process
 logger = logging.getLogger(__name__)
 
 
+def process_initializer():
+    """Initialize process pool workers."""
+    # Must apply patch in all worker processes.
+    import dtool_lookup_gui.utils.patch
+
+    # Avoids warning
+    #   PyGIWarning: Gtk was imported without specifying a version first.
+    #                Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
+    # when launching process pool. Would forking / spawning global process pool
+    # before Gtk initialization be another option?
+    import gi
+    gi.require_version('Gtk', '3.0')
+
+
 # inspired by
 # https://stackoverflow.com/questions/19924104/python-multiprocessing-handling-child-errors-in-parent
 class Process(multiprocessing.Process):

--- a/dtool_lookup_gui/utils/patch.py
+++ b/dtool_lookup_gui/utils/patch.py
@@ -1,0 +1,56 @@
+import logging
+import os
+import socket
+
+from dtoolcore.utils import IS_WINDOWS, windows_to_unix_path
+
+import dtoolcore.utils
+
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+def generous_parse_uri(uri):
+    """Return a urlparse.ParseResult object with the results of parsing the
+    given URI. This has the same properties as the result of parse_uri.
+    When passed a relative path, it determines the absolute path, sets the
+    scheme to file, the netloc to localhost and returns a parse of the result.
+    """
+    logger.debug("In generous_pase_uri...")
+    logger.debug("generous_pase_uri.input_uri: {}".format(uri))
+
+    parse_result = urlparse(uri)
+
+    IS_WINDOWS_DRIVE_LETTER = len(parse_result.scheme) == 1
+
+    if parse_result.scheme == '' or IS_WINDOWS_DRIVE_LETTER:
+        # ATTENTION: abspath apparently prepends the drive letter of the current working directory on Windows
+        if IS_WINDOWS_DRIVE_LETTER:
+            abspath = parse_result.scheme.upper() + ':' + parse_result.path
+        else:
+            abspath = os.path.abspath(parse_result.path)
+
+        fixed_uri = "file://{}{}".format(
+            socket.gethostname(),
+            abspath
+        )
+        if IS_WINDOWS:
+            abspath = windows_to_unix_path(abspath)
+            fixed_uri = "file:///{}".format(abspath)
+        parse_result = urlparse(fixed_uri)
+
+    logger.debug("generouse_pase_uri.return: {}".format(parse_result))
+    return parse_result
+
+# as of dtoolcore v3.18.1, we have to patch dtoolcore.utils.generous_parse_uri
+# to avoid a drive letter issue on windows. Otherwise, any drive letter within
+# a local windows path will be replaced by the drive letter of the current
+# working directory. See for example
+#   $ cygpath -wa .
+#   C:\msys64\home\
+#   $ python -c 'import os; from urllib.parse import urlparse; parse_result = urlparse("D:/test/path"); print(os.path.abspath(parse_result.path))'
+#   C:/test/path
+dtoolcore.utils.generous_parse_uri = generous_parse_uri

--- a/dtool_lookup_gui/views/main_window.py
+++ b/dtool_lookup_gui/views/main_window.py
@@ -49,7 +49,7 @@ from ..models.settings import settings
 from ..utils.copy_manager import CopyManager
 from ..utils.date import date_to_string
 from ..utils.dependency_graph import DependencyGraph
-from ..utils.logging import FormattedSingleMessageGtkInfoBarHandler
+from ..utils.logging import FormattedSingleMessageGtkInfoBarHandler, DefaultFilter
 from ..utils.query import (is_valid_query, dump_single_line_query_text)
 from ..widgets.base_uri_row import DtoolBaseURIRow
 from ..widgets.search_popover import DtoolSearchPopover
@@ -172,6 +172,8 @@ class MainWindow(Gtk.ApplicationWindow):
         # connect log handler to error bar
         root_logger = logging.getLogger()
         self.log_handler = FormattedSingleMessageGtkInfoBarHandler(info_bar=self.error_bar, label=self.error_label)
+        # exclude unwanted log messages from being displayed in error bar
+        self.log_handler.addFilter(DefaultFilter())
         root_logger.addHandler(self.log_handler)
 
         # connect a search popover with search entry

--- a/dtool_lookup_gui/views/main_window.py
+++ b/dtool_lookup_gui/views/main_window.py
@@ -375,6 +375,10 @@ class MainWindow(Gtk.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def on_base_uri_selected(self, list_box, row):
+        if row is None:
+            # this callback apparently gets evoked with row=None when an entry is deleted / unselected (?) from the base URI list
+            return
+
         def update_base_uri_summary(datasets):
             total_size = sum([0 if dataset.size_int is None else dataset.size_int for dataset in datasets])
             row.info_label.set_text(f'{len(datasets)} datasets, {sizeof_fmt(total_size).strip()}')
@@ -383,9 +387,10 @@ class MainWindow(Gtk.ApplicationWindow):
             row.start_spinner()
 
             if isinstance(row, DtoolBaseURIRow):
-                _logger.debug("Selected base URI.")
                 try:
+                    _logger.debug(f"Selected base URI {row.base_uri}.")
                     datasets = await row.base_uri.all_datasets()
+                    _logger.debug(f"Found {len(datasets)} datasets.")
                     update_base_uri_summary(datasets)
                     if self.base_uri_list_box.get_selected_row() == row:
                         # Only update if the row is still selected

--- a/dtool_lookup_gui/widgets/progress_popover_menu.py
+++ b/dtool_lookup_gui/widgets/progress_popover_menu.py
@@ -73,7 +73,10 @@ class DtoolProgressStatusBox(Gtk.Box):
 
     @property
     def fraction(self):
-        return self._step / self._length
+        if self._length > 0:
+            return self._step / self._length
+        else:
+            return 1.
 
     @property
     def is_done(self):

--- a/dtool_lookup_gui/widgets/search_popover.py
+++ b/dtool_lookup_gui/widgets/search_popover.py
@@ -24,7 +24,6 @@
 #
 
 import logging
-import logging
 import os
 
 from gi.repository import GLib, Gdk, Gtk, GtkSource

--- a/pyinstaller/dtool-lookup-gui-windows.spec
+++ b/pyinstaller/dtool-lookup-gui-windows.spec
@@ -13,6 +13,9 @@ glob_patterns_to_include =  [
     'dtool_lookup_gui/widgets/*.ui',
 ]
 
+with open(os.path.join(root_dir, 'openssl_dlls.txt'), 'r') as f:
+    lib_datas = [(os.path.abspath(line.strip()), '.') for line in f]
+
 additional_datas = [
     (os.path.join(root_dir, rel_path),
      os.path.join(os.curdir, os.path.dirname(rel_path))) for rel_path in glob_patterns_to_include
@@ -27,7 +30,7 @@ a = Analysis(
              pathex=[],
              binaries=[],
              datas=[
-                 *additional_datas,
+                 *lib_datas, *additional_datas,
              ],
              hiddenimports=[*other_hidden_imports],
              hookspath=[*hooks_path],


### PR DESCRIPTION
Multiprocessing on windows had been broken, in particular because

a) the Windows spawning mechanism needs to but cannot pickle objects without fully qualified names.
    Copying datasets on windows would hence fail with the locally defined `copy_func_wrapper`,

```
File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/views/main_window.py", line 566, in _copy
    await self._copy_manager.copy(self.dataset_list_box.get_selected_row().dataset, widget.destination)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/utils/copy_manager.py", line 40, in copy
    await dataset.copy(destination, progressbar=tracker)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/models/datasets.py", line 301, in copy
    await _copy_dataset(self.uri, target_base_uri, resume, auto_resume, progressbar)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/models/datasets.py", line 205, in _copy_dataset
    dest_uri = await non_blocking_copy_func(uri, target_base_uri)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/utils/multiprocessing.py", line 92, in __call__
    process.start()
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/context.py", line 327, in _Popen
    return Popen(process_obj)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/popen_spawn_win32.py", line 93, in __init__
    reduction.dump(process_obj, to_child)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object '_copy_dataset.<locals>.copy_func_wrapper'
```

b) tries to but cannot pickle Gtk objects
    This apparently happens with `target_wrapper` being a method of `StatusReportingChildProcessBuilder`, resulting in an attempt to pickle the whole instance of this object, including the reference to the `DtoolProgressStatusBox`, failing with

```
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/views/main_window.py", line 566, in _copy
    await self._copy_manager.copy(self.dataset_list_box.get_selected_row().dataset, widget.destination)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/utils/copy_manager.py", line 40, in copy
    await dataset.copy(destination, progressbar=tracker)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/models/datasets.py", line 309, in copy
    await _copy_dataset(self.uri, target_base_uri, resume, auto_resume, progressbar)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/models/datasets.py", line 213, in _copy_dataset
    dest_uri = await non_blocking_copy_func(uri, target_base_uri)
  File "C:/msys64\home\JohannesH▒rmann\git\dtool-lookup-gui/dtool_lookup_gui/utils/multiprocessing.py", line 92, in __call__
    process.start()
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/context.py", line 327, in _Popen
    return Popen(process_obj)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/popen_spawn_win32.py", line 93, in __init__
    reduction.dump(process_obj, to_child)
  File "C:/msys64/mingw64/lib/python3.9/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle 'DtoolProgressStatusBox' object
````

Refactoring by introducing `CopyFuncWrapper` and `TargetWrapper` as top-level classes solves the issue.